### PR TITLE
Copilot/add test cases for pr 1134

### DIFF
--- a/test_cases/fiber/devnet/list_channels/test_only_pending.py
+++ b/test_cases/fiber/devnet/list_channels/test_only_pending.py
@@ -1,0 +1,365 @@
+import time
+
+import pytest
+
+from framework.basic_fiber import FiberTest
+
+
+class TestListChannelsOnlyPending(FiberTest):
+    """
+    Tests for `list_channels` with the `only_pending` parameter introduced in
+    nervosnetwork/fiber#1134.
+
+    When `only_pending` is true the RPC should return:
+    - Channels in pre-ChannelReady states (NegotiatingFunding, CollaboratingFundingTx,
+      SigningCommitment, AwaitingTxSignatures, AwaitingChannelReady)
+    - Failed outbound openings (Closed(FUNDING_ABORTED) / Closed(ABANDONED)) with
+      `failure_detail`
+    - Inbound channel requests waiting for `accept_channel` (shown as
+      NegotiatingFunding with is_acceptor=true on the acceptor node)
+    """
+
+    def test_only_pending_shows_pending_channel(self):
+        """
+        When a channel is opened with auto-accept, it goes through pending states
+        before reaching CHANNEL_READY. We verify that `only_pending=true` returns
+        the channel while it is in a pending state, and stops returning it once
+        it reaches CHANNEL_READY.
+
+        Steps:
+        1. Open a channel between fiber1 and fiber2 (auto-accepted).
+        2. Wait until the channel reaches CHANNEL_READY.
+        3. Verify `only_pending=true` does NOT include CHANNEL_READY channels.
+        4. Verify `only_pending=false` (default) still shows the ready channel.
+        """
+        # Step 1: Open channel (auto-accepted, large funding amount)
+        self.fiber1.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(1000 * 100000000),
+                "public": True,
+            }
+        )
+
+        # Step 2: Wait for CHANNEL_READY
+        self.wait_for_channel_state(
+            self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
+        )
+
+        # Step 3: only_pending=true should NOT include CHANNEL_READY channels
+        pending_channels = self.fiber1.get_client().list_channels(
+            {"only_pending": True}
+        )
+        ready_in_pending = [
+            ch
+            for ch in pending_channels["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert (
+            len(ready_in_pending) == 0
+        ), "CHANNEL_READY channels should not appear when only_pending=true"
+
+        # Step 4: Default list (only_pending=false) should still show the channel
+        all_channels = self.fiber1.get_client().list_channels({})
+        assert len(all_channels["channels"]) >= 1
+        assert all_channels["channels"][0]["state"]["state_name"] == "CHANNEL_READY"
+
+    def test_only_pending_default_false(self):
+        """
+        Verify that the default behavior of `list_channels` (without `only_pending`)
+        is unchanged: it returns active channels.
+
+        Steps:
+        1. Open a channel and wait for CHANNEL_READY.
+        2. Call list_channels with only_pending=false (explicit).
+        3. Verify the CHANNEL_READY channel is returned.
+        """
+        self.fiber1.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(1000 * 100000000),
+                "public": True,
+            }
+        )
+        self.wait_for_channel_state(
+            self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
+        )
+
+        channels = self.fiber1.get_client().list_channels({"only_pending": False})
+        assert len(channels["channels"]) >= 1
+        assert channels["channels"][0]["state"]["state_name"] == "CHANNEL_READY"
+
+    def test_only_pending_shows_inbound_waiting_for_accept(self):
+        """
+        When a channel is opened with a funding amount below the auto-accept
+        threshold, the accepting node must manually call `accept_channel`.
+        Before acceptance, the channel should appear in the acceptor's
+        `list_channels(only_pending=true)` result as NegotiatingFunding with
+        is_acceptor=true.
+
+        Steps:
+        1. Get the auto-accept min funding amount.
+        2. Open a channel with funding_amount below the threshold (not auto-accepted).
+        3. On the acceptor node (fiber2), call list_channels(only_pending=true).
+        4. Verify the pending inbound channel is returned with is_acceptor=true
+           and state NegotiatingFunding.
+        5. Accept the channel and wait for CHANNEL_READY.
+        6. Verify only_pending=true no longer returns the channel.
+        """
+        # Step 1: Get auto-accept threshold
+        node_info = self.fiber1.get_client().node_info()
+        auto_accept_min = int(
+            node_info["open_channel_auto_accept_min_ckb_funding_amount"], 16
+        )
+
+        # Step 2: Open channel below threshold (requires manual accept)
+        temporary_channel = self.fiber1.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(auto_accept_min - 1),
+                "public": True,
+            }
+        )
+        time.sleep(2)
+
+        # Step 3: On the acceptor (fiber2), list_channels with only_pending=true
+        pending_channels = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
+
+        # Step 4: Verify the inbound channel appears
+        inbound_pending = [
+            ch
+            for ch in pending_channels["channels"]
+            if ch["state"]["state_name"] == "NEGOTIATING_FUNDING"
+            and ch["is_acceptor"] is True
+        ]
+        assert (
+            len(inbound_pending) >= 1
+        ), "Inbound channel waiting for accept_channel should appear in only_pending=true"
+        # The remote_balance should reflect the initiator's funding amount
+        assert int(inbound_pending[0]["remote_balance"], 16) > 0
+
+        # Step 5: Accept the channel
+        self.fiber2.get_client().accept_channel(
+            {
+                "temporary_channel_id": temporary_channel["temporary_channel_id"],
+                "funding_amount": hex(99 * 100000000),
+            }
+        )
+        self.wait_for_channel_state(
+            self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
+        )
+
+        # Step 6: only_pending=true should no longer return the (now ready) channel
+        pending_after = self.fiber2.get_client().list_channels({"only_pending": True})
+        ready_in_pending = [
+            ch
+            for ch in pending_after["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert len(ready_in_pending) == 0
+
+    def test_only_pending_shows_failed_channel_with_failure_detail(self):
+        """
+        When an outbound channel opening fails (e.g. peer disconnects during
+        opening), the failed record should appear in `list_channels(only_pending=true)`
+        with `failure_detail` set.
+
+        Steps:
+        1. Open a channel from fiber1 to fiber2 (auto-accept).
+        2. Before the channel is ready, stop fiber2 to simulate peer disconnection.
+        3. Wait for the channel to fail.
+        4. Call list_channels(only_pending=true) on fiber1.
+        5. Verify a failed channel record appears with failure_detail.
+        """
+        # Step 1: Open channel below auto-accept threshold from fiber3 to fiber2
+        # so that it requires manual accept, giving us time to disconnect
+        account3_private_key = self.generate_account(1000)
+        fiber3 = self.start_new_fiber(account3_private_key)
+        fiber3.connect_peer(self.fiber2)
+        time.sleep(1)
+
+        node_info = fiber3.get_client().node_info()
+        auto_accept_min = int(
+            node_info["open_channel_auto_accept_min_ckb_funding_amount"], 16
+        )
+
+        temporary_channel = fiber3.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(auto_accept_min - 1),
+                "public": True,
+            }
+        )
+        time.sleep(1)
+
+        # Step 2: Abandon the channel to make it fail
+        fiber3.get_client().abandon_channel(
+            {"channel_id": temporary_channel["temporary_channel_id"]}
+        )
+        time.sleep(2)
+
+        # Step 3: Check only_pending=true on fiber3
+        pending_channels = fiber3.get_client().list_channels({"only_pending": True})
+
+        # There should be at least one failed/abandoned channel record
+        # It may show as Closed(ABANDONED) or Closed(FUNDING_ABORTED) with failure_detail
+        failed_channels = [
+            ch
+            for ch in pending_channels["channels"]
+            if ch["state"]["state_name"] == "CLOSED"
+        ]
+        # The abandoned channel should appear with failure info
+        if len(failed_channels) > 0:
+            # If it has failure_detail, verify it's present
+            for fc in failed_channels:
+                assert fc["state"]["state_flags"] in (
+                    "ABANDONED",
+                    "FUNDING_ABORTED",
+                ), f"Unexpected close flag: {fc['state']['state_flags']}"
+
+    def test_only_pending_with_peer_id_filter(self):
+        """
+        Verify that `only_pending=true` respects the `peer_id` filter.
+
+        Steps:
+        1. Open channels with two different peers.
+        2. Wait for both to reach CHANNEL_READY.
+        3. Open a new channel below auto-accept threshold with one peer.
+        4. Call list_channels(only_pending=true, peer_id=...) to filter.
+        5. Verify only the matching peer's pending channel is returned.
+        """
+        # Step 1 & 2: Open channel with fiber2 (auto-accepted)
+        self.fiber1.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(1000 * 100000000),
+                "public": True,
+            }
+        )
+        self.wait_for_channel_state(
+            self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
+        )
+
+        # Create fiber3 and open a channel that needs manual accept
+        account3_private_key = self.generate_account(1000)
+        fiber3 = self.start_new_fiber(account3_private_key)
+        fiber3.connect_peer(self.fiber1)
+        time.sleep(1)
+
+        node_info = fiber3.get_client().node_info()
+        auto_accept_min = int(
+            node_info["open_channel_auto_accept_min_ckb_funding_amount"], 16
+        )
+
+        fiber3.get_client().open_channel(
+            {
+                "peer_id": self.fiber1.get_peer_id(),
+                "funding_amount": hex(auto_accept_min - 1),
+                "public": True,
+            }
+        )
+        time.sleep(2)
+
+        # Step 4: On fiber1, list only_pending with peer_id=fiber3's peer_id
+        pending_from_fiber3 = self.fiber1.get_client().list_channels(
+            {"only_pending": True, "peer_id": fiber3.get_peer_id()}
+        )
+
+        # Step 5: Should have pending channel from fiber3 only
+        assert len(pending_from_fiber3["channels"]) >= 1
+        for ch in pending_from_fiber3["channels"]:
+            assert ch["peer_id"] == fiber3.get_peer_id()
+
+        # Verify peer_id filter for fiber2 returns no pending (its channel is READY)
+        pending_from_fiber2 = self.fiber1.get_client().list_channels(
+            {"only_pending": True, "peer_id": self.fiber2.get_peer_id()}
+        )
+        ready_channels = [
+            ch
+            for ch in pending_from_fiber2["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert (
+            len(ready_channels) == 0
+        ), "CHANNEL_READY channels should not appear in only_pending=true"
+
+    def test_failure_detail_null_for_ready_channels(self):
+        """
+        Verify that the `failure_detail` field is null for successfully
+        opened channels.
+
+        Steps:
+        1. Open a channel and wait for CHANNEL_READY.
+        2. List channels (without only_pending).
+        3. Verify `failure_detail` is null.
+        """
+        self.fiber1.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(1000 * 100000000),
+                "public": True,
+            }
+        )
+        self.wait_for_channel_state(
+            self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
+        )
+
+        channels = self.fiber1.get_client().list_channels({})
+        assert len(channels["channels"]) >= 1
+        # failure_detail should be null for a successfully opened channel
+        assert channels["channels"][0]["failure_detail"] is None
+
+    def test_only_pending_peer_disconnect_shows_failure(self):
+        """
+        When a peer disconnects during channel opening, the channel should
+        appear as failed in `list_channels(only_pending=true)` with failure_detail.
+
+        Steps:
+        1. Start fiber3 and connect to fiber2.
+        2. Open a channel from fiber3 to fiber2 below auto-accept threshold.
+        3. Stop fiber2 to simulate disconnect before accept.
+        4. Wait for the channel actor to detect the disconnect and mark failure.
+        5. Verify list_channels(only_pending=true) on fiber3 shows the failed channel.
+        """
+        account3_private_key = self.generate_account(1000)
+        fiber3 = self.start_new_fiber(account3_private_key)
+        fiber3.connect_peer(self.fiber2)
+        time.sleep(1)
+
+        node_info = fiber3.get_client().node_info()
+        auto_accept_min = int(
+            node_info["open_channel_auto_accept_min_ckb_funding_amount"], 16
+        )
+
+        temporary_channel = fiber3.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(auto_accept_min - 1),
+                "public": True,
+            }
+        )
+        time.sleep(1)
+
+        # Disconnect fiber2 from fiber3
+        fiber3.get_client().disconnect_peer({"peer_id": self.fiber2.get_peer_id()})
+        # Wait for channel to detect disconnection and fail
+        time.sleep(5)
+
+        # Check pending channels on fiber3
+        pending_channels = fiber3.get_client().list_channels({"only_pending": True})
+
+        # The channel should appear (possibly as failed/closed or still pending)
+        # After disconnect, pending channels that haven't been accepted may
+        # show up with failure_detail or in a failed state
+        assert len(pending_channels["channels"]) >= 0  # May or may not have records
+
+        # Also verify the channel doesn't show in the normal (non-pending) list
+        normal_channels = fiber3.get_client().list_channels({})
+        ready_channels = [
+            ch
+            for ch in normal_channels["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert len(ready_channels) == 0

--- a/test_cases/fiber/devnet/list_channels/test_only_pending.py
+++ b/test_cases/fiber/devnet/list_channels/test_only_pending.py
@@ -1,7 +1,5 @@
 import time
 
-import pytest
-
 from framework.basic_fiber import FiberTest
 
 
@@ -167,14 +165,13 @@ class TestListChannelsOnlyPending(FiberTest):
         with `failure_detail` set.
 
         Steps:
-        1. Open a channel from fiber1 to fiber2 (auto-accept).
-        2. Before the channel is ready, stop fiber2 to simulate peer disconnection.
-        3. Wait for the channel to fail.
-        4. Call list_channels(only_pending=true) on fiber1.
-        5. Verify a failed channel record appears with failure_detail.
+        1. Start fiber3 and open a channel to fiber2 below auto-accept threshold.
+        2. Abandon the channel on fiber3 to trigger a failure.
+        3. Call list_channels(only_pending=true) on fiber3.
+        4. Verify a failed channel record appears with appropriate close flags.
         """
         # Step 1: Open channel below auto-accept threshold from fiber3 to fiber2
-        # so that it requires manual accept, giving us time to disconnect
+        # so that it requires manual accept, giving us time to abandon it
         account3_private_key = self.generate_account(1000)
         fiber3 = self.start_new_fiber(account3_private_key)
         fiber3.connect_peer(self.fiber2)
@@ -351,9 +348,16 @@ class TestListChannelsOnlyPending(FiberTest):
         pending_channels = fiber3.get_client().list_channels({"only_pending": True})
 
         # The channel should appear (possibly as failed/closed or still pending)
-        # After disconnect, pending channels that haven't been accepted may
-        # show up with failure_detail or in a failed state
-        assert len(pending_channels["channels"]) >= 0  # May or may not have records
+        # After disconnect, the channel actor may detect the disconnection and mark failure.
+        # We check that no CHANNEL_READY channels appear in the pending list.
+        ready_in_pending = [
+            ch
+            for ch in pending_channels["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert (
+            len(ready_in_pending) == 0
+        ), "CHANNEL_READY channels should not appear when only_pending=true"
 
         # Also verify the channel doesn't show in the normal (non-pending) list
         normal_channels = fiber3.get_client().list_channels({})

--- a/test_cases/fiber/devnet/list_channels/test_only_pending.py
+++ b/test_cases/fiber/devnet/list_channels/test_only_pending.py
@@ -26,9 +26,10 @@ class TestListChannelsOnlyPending(FiberTest):
 
         Steps:
         1. Open a channel between fiber1 and fiber2 (auto-accepted).
-        2. Wait until the channel reaches CHANNEL_READY.
-        3. Verify `only_pending=true` does NOT include CHANNEL_READY channels.
-        4. Verify `only_pending=false` (default) still shows the ready channel.
+        2. Wait until the channel reaches CHANNEL_READY on both sides.
+        3. Verify `only_pending=true` does NOT include CHANNEL_READY channels on fiber1.
+        4. Verify `only_pending=true` does NOT include CHANNEL_READY channels on fiber2.
+        5. Verify `only_pending=false` (default) still shows the ready channel on both sides.
         """
         # Step 1: Open channel (auto-accepted, large funding amount)
         self.fiber1.get_client().open_channel(
@@ -39,38 +40,62 @@ class TestListChannelsOnlyPending(FiberTest):
             }
         )
 
-        # Step 2: Wait for CHANNEL_READY
+        # Step 2: Wait for CHANNEL_READY on both sides
         self.wait_for_channel_state(
             self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
         )
+        self.wait_for_channel_state(
+            self.fiber2.get_client(), self.fiber1.get_peer_id(), "CHANNEL_READY", 120
+        )
 
-        # Step 3: only_pending=true should NOT include CHANNEL_READY channels
-        pending_channels = self.fiber1.get_client().list_channels(
+        # Step 3: only_pending=true should NOT include CHANNEL_READY channels on fiber1
+        pending_channels_fiber1 = self.fiber1.get_client().list_channels(
             {"only_pending": True}
         )
-        ready_in_pending = [
+        ready_in_pending_fiber1 = [
             ch
-            for ch in pending_channels["channels"]
+            for ch in pending_channels_fiber1["channels"]
             if ch["state"]["state_name"] == "CHANNEL_READY"
         ]
         assert (
-            len(ready_in_pending) == 0
-        ), "CHANNEL_READY channels should not appear when only_pending=true"
+            len(ready_in_pending_fiber1) == 0
+        ), "CHANNEL_READY channels should not appear when only_pending=true on fiber1"
 
-        # Step 4: Default list (only_pending=false) should still show the channel
-        all_channels = self.fiber1.get_client().list_channels({})
-        assert len(all_channels["channels"]) >= 1
-        assert all_channels["channels"][0]["state"]["state_name"] == "CHANNEL_READY"
+        # Step 4: only_pending=true should NOT include CHANNEL_READY channels on fiber2
+        pending_channels_fiber2 = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
+        ready_in_pending_fiber2 = [
+            ch
+            for ch in pending_channels_fiber2["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert (
+            len(ready_in_pending_fiber2) == 0
+        ), "CHANNEL_READY channels should not appear when only_pending=true on fiber2"
+
+        # Step 5: Default list (only_pending=false) should still show the channel on both sides
+        all_channels_fiber1 = self.fiber1.get_client().list_channels({})
+        assert len(all_channels_fiber1["channels"]) >= 1
+        assert (
+            all_channels_fiber1["channels"][0]["state"]["state_name"] == "CHANNEL_READY"
+        )
+
+        all_channels_fiber2 = self.fiber2.get_client().list_channels({})
+        assert len(all_channels_fiber2["channels"]) >= 1
+        assert (
+            all_channels_fiber2["channels"][0]["state"]["state_name"] == "CHANNEL_READY"
+        )
 
     def test_only_pending_default_false(self):
         """
         Verify that the default behavior of `list_channels` (without `only_pending`)
-        is unchanged: it returns active channels.
+        is unchanged: it returns active channels on both sides.
 
         Steps:
-        1. Open a channel and wait for CHANNEL_READY.
-        2. Call list_channels with only_pending=false (explicit).
-        3. Verify the CHANNEL_READY channel is returned.
+        1. Open a channel and wait for CHANNEL_READY on both sides.
+        2. Call list_channels with only_pending=false (explicit) on both nodes.
+        3. Verify the CHANNEL_READY channel is returned on both sides.
         """
         self.fiber1.get_client().open_channel(
             {
@@ -82,27 +107,39 @@ class TestListChannelsOnlyPending(FiberTest):
         self.wait_for_channel_state(
             self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
         )
+        self.wait_for_channel_state(
+            self.fiber2.get_client(), self.fiber1.get_peer_id(), "CHANNEL_READY", 120
+        )
 
-        channels = self.fiber1.get_client().list_channels({"only_pending": False})
-        assert len(channels["channels"]) >= 1
-        assert channels["channels"][0]["state"]["state_name"] == "CHANNEL_READY"
+        # Check fiber1 side
+        channels_fiber1 = self.fiber1.get_client().list_channels(
+            {"only_pending": False}
+        )
+        assert len(channels_fiber1["channels"]) >= 1
+        assert channels_fiber1["channels"][0]["state"]["state_name"] == "CHANNEL_READY"
+
+        # Check fiber2 side
+        channels_fiber2 = self.fiber2.get_client().list_channels(
+            {"only_pending": False}
+        )
+        assert len(channels_fiber2["channels"]) >= 1
+        assert channels_fiber2["channels"][0]["state"]["state_name"] == "CHANNEL_READY"
 
     def test_only_pending_shows_inbound_waiting_for_accept(self):
         """
         When a channel is opened with a funding amount below the auto-accept
         threshold, the accepting node must manually call `accept_channel`.
-        Before acceptance, the channel should appear in the acceptor's
-        `list_channels(only_pending=true)` result as NegotiatingFunding with
-        is_acceptor=true.
+        Before acceptance, the channel should appear in both nodes'
+        `list_channels(only_pending=true)` results.
 
         Steps:
         1. Get the auto-accept min funding amount.
         2. Open a channel with funding_amount below the threshold (not auto-accepted).
-        3. On the acceptor node (fiber2), call list_channels(only_pending=true).
-        4. Verify the pending inbound channel is returned with is_acceptor=true
-           and state NegotiatingFunding.
-        5. Accept the channel and wait for CHANNEL_READY.
-        6. Verify only_pending=true no longer returns the channel.
+        3. On the initiator (fiber1), verify the pending outbound channel appears.
+        4. On the acceptor (fiber2), verify the pending inbound channel appears
+           with is_acceptor=true and state NegotiatingFunding.
+        5. Accept the channel and wait for CHANNEL_READY on both sides.
+        6. Verify only_pending=true no longer returns the channel on both sides.
         """
         # Step 1: Get auto-accept threshold
         node_info = self.fiber1.get_client().node_info()
@@ -120,25 +157,37 @@ class TestListChannelsOnlyPending(FiberTest):
         )
         time.sleep(2)
 
-        # Step 3: On the acceptor (fiber2), list_channels with only_pending=true
-        pending_channels = self.fiber2.get_client().list_channels(
+        # Step 3: On the initiator (fiber1), verify pending outbound channel
+        pending_channels_fiber1 = self.fiber1.get_client().list_channels(
             {"only_pending": True}
         )
+        outbound_pending = [
+            ch
+            for ch in pending_channels_fiber1["channels"]
+            if ch["is_acceptor"] is False
+        ]
+        assert len(outbound_pending) >= 1, (
+            "Initiator (fiber1) should see pending outbound channel "
+            "in list_channels(only_pending=true) before peer accepts"
+        )
 
-        # Step 4: Verify the inbound channel appears
+        # Step 4: On the acceptor (fiber2), verify pending inbound channel
+        pending_channels_fiber2 = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
         inbound_pending = [
             ch
-            for ch in pending_channels["channels"]
+            for ch in pending_channels_fiber2["channels"]
             if ch["state"]["state_name"] == "NEGOTIATING_FUNDING"
             and ch["is_acceptor"] is True
         ]
         assert (
             len(inbound_pending) >= 1
-        ), "Inbound channel waiting for accept_channel should appear in only_pending=true"
+        ), "Inbound channel waiting for accept_channel should appear in only_pending=true on fiber2"
         # The remote_balance should reflect the initiator's funding amount
         assert int(inbound_pending[0]["remote_balance"], 16) > 0
 
-        # Step 5: Accept the channel
+        # Step 5: Accept the channel and wait for CHANNEL_READY on both sides
         self.fiber2.get_client().accept_channel(
             {
                 "temporary_channel_id": temporary_channel["temporary_channel_id"],
@@ -148,15 +197,34 @@ class TestListChannelsOnlyPending(FiberTest):
         self.wait_for_channel_state(
             self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
         )
+        self.wait_for_channel_state(
+            self.fiber2.get_client(), self.fiber1.get_peer_id(), "CHANNEL_READY", 120
+        )
 
-        # Step 6: only_pending=true should no longer return the (now ready) channel
-        pending_after = self.fiber2.get_client().list_channels({"only_pending": True})
-        ready_in_pending = [
+        # Step 6: only_pending=true should no longer return the channel on either side
+        pending_after_fiber1 = self.fiber1.get_client().list_channels(
+            {"only_pending": True}
+        )
+        ready_in_pending_fiber1 = [
             ch
-            for ch in pending_after["channels"]
+            for ch in pending_after_fiber1["channels"]
             if ch["state"]["state_name"] == "CHANNEL_READY"
         ]
-        assert len(ready_in_pending) == 0
+        assert (
+            len(ready_in_pending_fiber1) == 0
+        ), "CHANNEL_READY should not appear in only_pending=true on fiber1"
+
+        pending_after_fiber2 = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
+        ready_in_pending_fiber2 = [
+            ch
+            for ch in pending_after_fiber2["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert (
+            len(ready_in_pending_fiber2) == 0
+        ), "CHANNEL_READY should not appear in only_pending=true on fiber2"
 
     def test_only_pending_initiator_sees_outbound_pending_channel(self):
         """
@@ -228,15 +296,16 @@ class TestListChannelsOnlyPending(FiberTest):
 
     def test_only_pending_shows_failed_channel_with_failure_detail(self):
         """
-        When an outbound channel opening fails (e.g. peer disconnects during
+        When an outbound channel opening fails (e.g. channel is abandoned during
         opening), the failed record should appear in `list_channels(only_pending=true)`
-        with `failure_detail` set.
+        with `failure_detail` set. Both the abandoning node and the peer should be checked.
 
         Steps:
         1. Start fiber3 and open a channel to fiber2 below auto-accept threshold.
         2. Abandon the channel on fiber3 to trigger a failure.
         3. Call list_channels(only_pending=true) on fiber3.
         4. Verify a failed channel record appears with appropriate close flags.
+        5. Call list_channels(only_pending=true) on fiber2 to verify peer side state.
         """
         # Step 1: Open channel below auto-accept threshold from fiber3 to fiber2
         # so that it requires manual accept, giving us time to abandon it
@@ -265,37 +334,53 @@ class TestListChannelsOnlyPending(FiberTest):
         )
         time.sleep(2)
 
-        # Step 3: Check only_pending=true on fiber3
-        pending_channels = fiber3.get_client().list_channels({"only_pending": True})
+        # Step 3: Check only_pending=true on fiber3 (the node that abandoned)
+        pending_channels_fiber3 = fiber3.get_client().list_channels(
+            {"only_pending": True}
+        )
 
         # There should be at least one failed/abandoned channel record
         # It may show as Closed(ABANDONED) or Closed(FUNDING_ABORTED) with failure_detail
-        failed_channels = [
+        failed_channels_fiber3 = [
             ch
-            for ch in pending_channels["channels"]
+            for ch in pending_channels_fiber3["channels"]
             if ch["state"]["state_name"] == "CLOSED"
         ]
         # The abandoned channel should appear with failure info
-        if len(failed_channels) > 0:
-            # If it has failure_detail, verify it's present
-            for fc in failed_channels:
+        if len(failed_channels_fiber3) > 0:
+            for fc in failed_channels_fiber3:
                 assert fc["state"]["state_flags"] in (
                     "ABANDONED",
                     "FUNDING_ABORTED",
-                ), f"Unexpected close flag: {fc['state']['state_flags']}"
+                ), f"Unexpected close flag on fiber3: {fc['state']['state_flags']}"
+
+        # Step 5: Check only_pending=true on fiber2 (the peer side)
+        # After fiber3 abandons, fiber2 should not have a CHANNEL_READY channel
+        pending_channels_fiber2 = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
+        ready_in_pending_fiber2 = [
+            ch
+            for ch in pending_channels_fiber2["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert len(ready_in_pending_fiber2) == 0, (
+            "CHANNEL_READY should not appear in only_pending=true on fiber2 "
+            "after fiber3 abandoned the channel"
+        )
 
     def test_only_pending_with_peer_id_filter(self):
         """
-        Verify that `only_pending=true` respects the `peer_id` filter.
+        Verify that `only_pending=true` respects the `peer_id` filter on both sides.
 
         Steps:
-        1. Open channels with two different peers.
-        2. Wait for both to reach CHANNEL_READY.
-        3. Open a new channel below auto-accept threshold with one peer.
-        4. Call list_channels(only_pending=true, peer_id=...) to filter.
-        5. Verify only the matching peer's pending channel is returned.
+        1. Open channel with fiber2 and wait for CHANNEL_READY.
+        2. Create fiber3 and open a channel below auto-accept threshold to fiber1.
+        3. On fiber1, list only_pending with peer_id=fiber3 → should have pending channel.
+        4. On fiber1, list only_pending with peer_id=fiber2 → should have no pending.
+        5. On fiber3, list only_pending with peer_id=fiber1 → should have pending channel.
         """
-        # Step 1 & 2: Open channel with fiber2 (auto-accepted)
+        # Step 1: Open channel with fiber2 (auto-accepted)
         self.fiber1.get_client().open_channel(
             {
                 "peer_id": self.fiber2.get_peer_id(),
@@ -307,7 +392,7 @@ class TestListChannelsOnlyPending(FiberTest):
             self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
         )
 
-        # Create fiber3 and open a channel that needs manual accept
+        # Step 2: Create fiber3 and open a channel that needs manual accept
         account3_private_key = self.generate_account(1000)
         fiber3 = self.start_new_fiber(account3_private_key)
         fiber3.connect_peer(self.fiber1)
@@ -327,17 +412,15 @@ class TestListChannelsOnlyPending(FiberTest):
         )
         time.sleep(2)
 
-        # Step 4: On fiber1, list only_pending with peer_id=fiber3's peer_id
+        # Step 3: On fiber1, list only_pending with peer_id=fiber3's peer_id
         pending_from_fiber3 = self.fiber1.get_client().list_channels(
             {"only_pending": True, "peer_id": fiber3.get_peer_id()}
         )
-
-        # Step 5: Should have pending channel from fiber3 only
         assert len(pending_from_fiber3["channels"]) >= 1
         for ch in pending_from_fiber3["channels"]:
             assert ch["peer_id"] == fiber3.get_peer_id()
 
-        # Verify peer_id filter for fiber2 returns no pending (its channel is READY)
+        # Step 4: Verify peer_id filter for fiber2 returns no pending (its channel is READY)
         pending_from_fiber2 = self.fiber1.get_client().list_channels(
             {"only_pending": True, "peer_id": self.fiber2.get_peer_id()}
         )
@@ -350,15 +433,26 @@ class TestListChannelsOnlyPending(FiberTest):
             len(ready_channels) == 0
         ), "CHANNEL_READY channels should not appear in only_pending=true"
 
+        # Step 5: On fiber3 (initiator), list only_pending with peer_id=fiber1
+        pending_on_fiber3 = fiber3.get_client().list_channels(
+            {"only_pending": True, "peer_id": self.fiber1.get_peer_id()}
+        )
+        assert len(pending_on_fiber3["channels"]) >= 1, (
+            "Initiator (fiber3) should see pending outbound channel "
+            "in list_channels(only_pending=true, peer_id=fiber1)"
+        )
+        for ch in pending_on_fiber3["channels"]:
+            assert ch["peer_id"] == self.fiber1.get_peer_id()
+
     def test_failure_detail_null_for_ready_channels(self):
         """
         Verify that the `failure_detail` field is null for successfully
-        opened channels.
+        opened channels on both sides.
 
         Steps:
-        1. Open a channel and wait for CHANNEL_READY.
-        2. List channels (without only_pending).
-        3. Verify `failure_detail` is null.
+        1. Open a channel and wait for CHANNEL_READY on both sides.
+        2. List channels on both nodes (without only_pending).
+        3. Verify `failure_detail` is null on both sides.
         """
         self.fiber1.get_client().open_channel(
             {
@@ -370,23 +464,38 @@ class TestListChannelsOnlyPending(FiberTest):
         self.wait_for_channel_state(
             self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
         )
+        self.wait_for_channel_state(
+            self.fiber2.get_client(), self.fiber1.get_peer_id(), "CHANNEL_READY", 120
+        )
 
-        channels = self.fiber1.get_client().list_channels({})
-        assert len(channels["channels"]) >= 1
-        # failure_detail should be null for a successfully opened channel
-        assert channels["channels"][0]["failure_detail"] is None
+        # Check fiber1 side
+        channels_fiber1 = self.fiber1.get_client().list_channels({})
+        assert len(channels_fiber1["channels"]) >= 1
+        assert (
+            channels_fiber1["channels"][0]["failure_detail"] is None
+        ), "failure_detail should be null for a successfully opened channel on fiber1"
+
+        # Check fiber2 side
+        channels_fiber2 = self.fiber2.get_client().list_channels({})
+        assert len(channels_fiber2["channels"]) >= 1
+        assert (
+            channels_fiber2["channels"][0]["failure_detail"] is None
+        ), "failure_detail should be null for a successfully opened channel on fiber2"
 
     def test_only_pending_peer_disconnect_shows_failure(self):
         """
         When a peer disconnects during channel opening, the channel should
-        appear as failed in `list_channels(only_pending=true)` with failure_detail.
+        appear as failed in `list_channels(only_pending=true)`. Both sides
+        should be checked.
 
         Steps:
         1. Start fiber3 and connect to fiber2.
         2. Open a channel from fiber3 to fiber2 below auto-accept threshold.
-        3. Stop fiber2 to simulate disconnect before accept.
+        3. Disconnect fiber2 from fiber3 to simulate disconnect before accept.
         4. Wait for the channel actor to detect the disconnect and mark failure.
-        5. Verify list_channels(only_pending=true) on fiber3 shows the failed channel.
+        5. Verify list_channels(only_pending=true) on fiber3 has no CHANNEL_READY.
+        6. Verify list_channels(only_pending=true) on fiber2 has no CHANNEL_READY.
+        7. Verify normal list_channels on both sides has no CHANNEL_READY.
         """
         account3_private_key = self.generate_account(1000)
         fiber3 = self.start_new_fiber(account3_private_key)
@@ -412,26 +521,46 @@ class TestListChannelsOnlyPending(FiberTest):
         # Wait for channel to detect disconnection and fail
         time.sleep(5)
 
-        # Check pending channels on fiber3
-        pending_channels = fiber3.get_client().list_channels({"only_pending": True})
-
-        # The channel should appear (possibly as failed/closed or still pending)
-        # After disconnect, the channel actor may detect the disconnection and mark failure.
-        # We check that no CHANNEL_READY channels appear in the pending list.
-        ready_in_pending = [
+        # Step 5: Check pending channels on fiber3
+        pending_channels_fiber3 = fiber3.get_client().list_channels(
+            {"only_pending": True}
+        )
+        ready_in_pending_fiber3 = [
             ch
-            for ch in pending_channels["channels"]
+            for ch in pending_channels_fiber3["channels"]
             if ch["state"]["state_name"] == "CHANNEL_READY"
         ]
         assert (
-            len(ready_in_pending) == 0
-        ), "CHANNEL_READY channels should not appear when only_pending=true"
+            len(ready_in_pending_fiber3) == 0
+        ), "CHANNEL_READY channels should not appear when only_pending=true on fiber3"
 
-        # Also verify the channel doesn't show in the normal (non-pending) list
-        normal_channels = fiber3.get_client().list_channels({})
-        ready_channels = [
+        # Step 6: Check pending channels on fiber2 (the peer side)
+        pending_channels_fiber2 = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
+        ready_in_pending_fiber2 = [
             ch
-            for ch in normal_channels["channels"]
+            for ch in pending_channels_fiber2["channels"]
             if ch["state"]["state_name"] == "CHANNEL_READY"
         ]
-        assert len(ready_channels) == 0
+        assert (
+            len(ready_in_pending_fiber2) == 0
+        ), "CHANNEL_READY channels should not appear when only_pending=true on fiber2"
+
+        # Step 7: Also verify no CHANNEL_READY in the normal list on both sides
+        normal_channels_fiber3 = fiber3.get_client().list_channels({})
+        ready_channels_fiber3 = [
+            ch
+            for ch in normal_channels_fiber3["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert len(ready_channels_fiber3) == 0
+
+        normal_channels_fiber2 = self.fiber2.get_client().list_channels({})
+        ready_channels_fiber2 = [
+            ch
+            for ch in normal_channels_fiber2["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+            and ch["peer_id"] == fiber3.get_peer_id()
+        ]
+        assert len(ready_channels_fiber2) == 0

--- a/test_cases/fiber/devnet/list_channels/test_only_pending.py
+++ b/test_cases/fiber/devnet/list_channels/test_only_pending.py
@@ -789,3 +789,93 @@ class TestListChannelsOnlyPending(FiberTest):
             f"failure_detail should be preserved after restart. "
             f"Before: {failure_detail_before}, After: {matching_channel['failure_detail']}"
         )
+
+    def test_only_pending_no_duplicate_channel_ids_before_accept(self):
+        """
+        When fiber1 opens a channel with funding_amount below the auto-accept
+        threshold (requiring manual accept_channel from fiber2), the
+        `list_channels(only_pending=true)` results on both sides should:
+
+        - Return exactly one channel entry per channel_id (no duplicates).
+        - On the initiator (fiber1), local_balance should reflect the
+          funding amount (not 0x0).
+        - On the acceptor (fiber2), remote_balance should reflect the
+          initiator's funding amount (not 0x0), and there should be
+          exactly one channel entry (not two with different remote_balance).
+
+        This reproduces a bug where fiber2 returned two channels with the
+        same channel_id: one with remote_balance=0x0 and another with
+        remote_balance != 0x0.
+
+        Steps:
+        1. Get the auto-accept min funding amount.
+        2. Open a channel with funding_amount below the threshold.
+        3. On both sides, call list_channels(only_pending=true).
+        4. Verify no duplicate channel_ids on either side.
+        5. Verify fiber1's local_balance matches funding_amount.
+        6. Verify fiber2's remote_balance matches funding_amount.
+        """
+        # Step 1: Get auto-accept threshold
+        node_info = self.fiber1.get_client().node_info()
+        auto_accept_min = int(
+            node_info["open_channel_auto_accept_min_ckb_funding_amount"], 16
+        )
+
+        # Step 2: Open channel below threshold (requires manual accept)
+        funding_amount = auto_accept_min - 1
+        self.fiber1.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(funding_amount),
+                "public": True,
+            }
+        )
+        time.sleep(2)
+
+        # Step 3: Query both sides
+        pending_fiber1 = self.fiber1.get_client().list_channels({"only_pending": True})
+        pending_fiber2 = self.fiber2.get_client().list_channels({"only_pending": True})
+
+        # Step 4a: Verify no duplicate channel_ids on fiber1
+        channel_ids_fiber1 = [ch["channel_id"] for ch in pending_fiber1["channels"]]
+        assert len(channel_ids_fiber1) == len(set(channel_ids_fiber1)), (
+            f"fiber1 list_channels(only_pending=true) returned duplicate channel_ids: "
+            f"{channel_ids_fiber1}"
+        )
+
+        # Step 4b: Verify no duplicate channel_ids on fiber2
+        channel_ids_fiber2 = [ch["channel_id"] for ch in pending_fiber2["channels"]]
+        assert len(channel_ids_fiber2) == len(set(channel_ids_fiber2)), (
+            f"fiber2 list_channels(only_pending=true) returned duplicate channel_ids: "
+            f"{channel_ids_fiber2}"
+        )
+
+        # Step 5: Verify fiber1 (initiator) has exactly one pending outbound channel
+        # and its local_balance reflects the funding_amount
+        outbound_pending = [
+            ch for ch in pending_fiber1["channels"] if ch["is_acceptor"] is False
+        ]
+        assert len(outbound_pending) == 1, (
+            f"fiber1 should have exactly 1 pending outbound channel, "
+            f"got {len(outbound_pending)}"
+        )
+        fiber1_local_balance = int(outbound_pending[0]["local_balance"], 16)
+        assert fiber1_local_balance > 0, (
+            f"Initiator (fiber1) local_balance should reflect the funding amount "
+            f"(expected > 0), got {hex(fiber1_local_balance)}"
+        )
+
+        # Step 6: Verify fiber2 (acceptor) has exactly one pending inbound channel
+        # and its remote_balance reflects the initiator's funding amount
+        inbound_pending = [
+            ch for ch in pending_fiber2["channels"] if ch["is_acceptor"] is True
+        ]
+        assert len(inbound_pending) == 1, (
+            f"fiber2 should have exactly 1 pending inbound channel, "
+            f"got {len(inbound_pending)}"
+        )
+        fiber2_remote_balance = int(inbound_pending[0]["remote_balance"], 16)
+        assert fiber2_remote_balance > 0, (
+            f"Acceptor (fiber2) remote_balance should reflect the initiator's "
+            f"funding amount (expected > 0), got {hex(fiber2_remote_balance)}"
+        )

--- a/test_cases/fiber/devnet/list_channels/test_only_pending.py
+++ b/test_cases/fiber/devnet/list_channels/test_only_pending.py
@@ -304,7 +304,8 @@ class TestListChannelsOnlyPending(FiberTest):
         1. Start fiber3 and open a channel to fiber2 below auto-accept threshold.
         2. Abandon the channel on fiber3 to trigger a failure.
         3. Call list_channels(only_pending=true) on fiber3.
-        4. Verify a failed channel record appears with appropriate close flags.
+        4. Verify a failed channel record appears with appropriate close flags
+           and a non-empty failure_detail string.
         5. Call list_channels(only_pending=true) on fiber2 to verify peer side state.
         """
         # Step 1: Open channel below auto-accept threshold from fiber3 to fiber2
@@ -339,20 +340,32 @@ class TestListChannelsOnlyPending(FiberTest):
             {"only_pending": True}
         )
 
-        # There should be at least one failed/abandoned channel record
-        # It may show as Closed(ABANDONED) or Closed(FUNDING_ABORTED) with failure_detail
+        # Step 4: There MUST be at least one failed/abandoned channel record
         failed_channels_fiber3 = [
             ch
             for ch in pending_channels_fiber3["channels"]
             if ch["state"]["state_name"] == "CLOSED"
         ]
-        # The abandoned channel should appear with failure info
-        if len(failed_channels_fiber3) > 0:
-            for fc in failed_channels_fiber3:
-                assert fc["state"]["state_flags"] in (
-                    "ABANDONED",
-                    "FUNDING_ABORTED",
-                ), f"Unexpected close flag on fiber3: {fc['state']['state_flags']}"
+        assert (
+            len(failed_channels_fiber3) >= 1
+        ), "Abandoned channel should appear as CLOSED in only_pending=true on fiber3"
+
+        for fc in failed_channels_fiber3:
+            # Verify close flags
+            assert fc["state"]["state_flags"] in (
+                "ABANDONED",
+                "FUNDING_ABORTED",
+            ), f"Unexpected close flag on fiber3: {fc['state']['state_flags']}"
+            # Verify failure_detail is present and non-empty
+            assert (
+                fc["failure_detail"] is not None
+            ), "failure_detail must not be None for abandoned channel on fiber3"
+            assert isinstance(
+                fc["failure_detail"], str
+            ), f"failure_detail should be a string, got {type(fc['failure_detail'])}"
+            assert (
+                len(fc["failure_detail"]) > 0
+            ), "failure_detail must not be empty for abandoned channel on fiber3"
 
         # Step 5: Check only_pending=true on fiber2 (the peer side)
         # After fiber3 abandons, fiber2 should not have a CHANNEL_READY channel
@@ -564,3 +577,215 @@ class TestListChannelsOnlyPending(FiberTest):
             and ch["peer_id"] == fiber3.get_peer_id()
         ]
         assert len(ready_channels_fiber2) == 0
+
+    def test_only_pending_survives_restart_ready_channel(self):
+        """
+        After a channel reaches CHANNEL_READY, restarting both nodes should not
+        affect the `only_pending=true` query: the CHANNEL_READY channel should
+        still be excluded from `only_pending=true` and still visible in the
+        default `list_channels` on both sides.
+
+        Steps:
+        1. Open a channel and wait for CHANNEL_READY on both sides.
+        2. Verify only_pending=true excludes it on both sides before restart.
+        3. Restart fiber1 and fiber2.
+        4. Reconnect and wait for peers.
+        5. Verify only_pending=true still excludes the CHANNEL_READY channel
+           on both sides after restart.
+        6. Verify default list_channels still shows the CHANNEL_READY channel
+           on both sides after restart.
+        """
+        # Step 1: Open channel and wait for CHANNEL_READY
+        self.fiber1.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(1000 * 100000000),
+                "public": True,
+            }
+        )
+        self.wait_for_channel_state(
+            self.fiber1.get_client(), self.fiber2.get_peer_id(), "CHANNEL_READY", 120
+        )
+        self.wait_for_channel_state(
+            self.fiber2.get_client(), self.fiber1.get_peer_id(), "CHANNEL_READY", 120
+        )
+
+        # Step 2: Verify only_pending=true excludes CHANNEL_READY before restart
+        pending_fiber1_before = self.fiber1.get_client().list_channels(
+            {"only_pending": True}
+        )
+        assert all(
+            ch["state"]["state_name"] != "CHANNEL_READY"
+            for ch in pending_fiber1_before["channels"]
+        ), "CHANNEL_READY should not appear in only_pending=true on fiber1 before restart"
+
+        pending_fiber2_before = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
+        assert all(
+            ch["state"]["state_name"] != "CHANNEL_READY"
+            for ch in pending_fiber2_before["channels"]
+        ), "CHANNEL_READY should not appear in only_pending=true on fiber2 before restart"
+
+        # Step 3: Restart both fiber nodes
+        self.fiber1.stop()
+        self.fiber2.stop()
+        self.fiber1.start()
+        self.fiber2.start()
+        time.sleep(3)
+
+        # Step 4: Reconnect peers
+        self.fiber1.connect_peer(self.fiber2)
+        time.sleep(3)
+
+        # Step 5: Verify only_pending=true still excludes CHANNEL_READY after restart
+        pending_fiber1_after = self.fiber1.get_client().list_channels(
+            {"only_pending": True}
+        )
+        assert all(
+            ch["state"]["state_name"] != "CHANNEL_READY"
+            for ch in pending_fiber1_after["channels"]
+        ), "CHANNEL_READY should not appear in only_pending=true on fiber1 after restart"
+
+        pending_fiber2_after = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
+        assert all(
+            ch["state"]["state_name"] != "CHANNEL_READY"
+            for ch in pending_fiber2_after["channels"]
+        ), "CHANNEL_READY should not appear in only_pending=true on fiber2 after restart"
+
+        # Step 6: Verify default list still shows the CHANNEL_READY channel after restart
+        all_channels_fiber1 = self.fiber1.get_client().list_channels({})
+        ready_fiber1 = [
+            ch
+            for ch in all_channels_fiber1["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert (
+            len(ready_fiber1) >= 1
+        ), "CHANNEL_READY channel should still be visible in default list on fiber1 after restart"
+
+        all_channels_fiber2 = self.fiber2.get_client().list_channels({})
+        ready_fiber2 = [
+            ch
+            for ch in all_channels_fiber2["channels"]
+            if ch["state"]["state_name"] == "CHANNEL_READY"
+        ]
+        assert (
+            len(ready_fiber2) >= 1
+        ), "CHANNEL_READY channel should still be visible in default list on fiber2 after restart"
+
+    def test_only_pending_survives_restart_abandoned_channel(self):
+        """
+        After a channel is abandoned and visible in `only_pending=true` with
+        a non-empty `failure_detail`, restarting the node should preserve that
+        failed record: it should still appear in `only_pending=true` with the
+        same failure information.
+
+        Steps:
+        1. Start fiber3 and open a channel to fiber2 below auto-accept threshold.
+        2. Abandon the channel on fiber3.
+        3. Verify the abandoned channel appears in only_pending=true on fiber3
+           with failure_detail and correct close flags.
+        4. Restart fiber3.
+        5. After restart, verify the abandoned channel still appears in
+           only_pending=true on fiber3 with failure_detail and correct close flags.
+        """
+        # Step 1: Start fiber3 and open channel below auto-accept threshold
+        account3_private_key = self.generate_account(1000)
+        fiber3 = self.start_new_fiber(account3_private_key)
+        fiber3.connect_peer(self.fiber2)
+        time.sleep(1)
+
+        node_info = fiber3.get_client().node_info()
+        auto_accept_min = int(
+            node_info["open_channel_auto_accept_min_ckb_funding_amount"], 16
+        )
+
+        temporary_channel = fiber3.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(auto_accept_min - 1),
+                "public": True,
+            }
+        )
+        time.sleep(1)
+
+        # Step 2: Abandon the channel
+        fiber3.get_client().abandon_channel(
+            {"channel_id": temporary_channel["temporary_channel_id"]}
+        )
+        time.sleep(2)
+
+        # Step 3: Verify before restart — failed channel must appear with failure_detail
+        pending_before = fiber3.get_client().list_channels({"only_pending": True})
+        failed_before = [
+            ch
+            for ch in pending_before["channels"]
+            if ch["state"]["state_name"] == "CLOSED"
+        ]
+        assert (
+            len(failed_before) >= 1
+        ), "Abandoned channel should appear as CLOSED in only_pending=true on fiber3 before restart"
+
+        for fc in failed_before:
+            assert fc["state"]["state_flags"] in (
+                "ABANDONED",
+                "FUNDING_ABORTED",
+            ), f"Unexpected close flag before restart: {fc['state']['state_flags']}"
+            assert (
+                fc["failure_detail"] is not None
+            ), "failure_detail must not be None for abandoned channel before restart"
+            assert (
+                isinstance(fc["failure_detail"], str) and len(fc["failure_detail"]) > 0
+            ), "failure_detail must be a non-empty string before restart"
+
+        # Save channel info for comparison after restart
+        failed_channel_id_before = failed_before[0]["channel_id"]
+        failure_detail_before = failed_before[0]["failure_detail"]
+
+        # Step 4: Restart fiber3
+        fiber3.stop()
+        fiber3.start()
+        time.sleep(3)
+
+        # Step 5: After restart, verify the abandoned channel still appears
+        pending_after = fiber3.get_client().list_channels({"only_pending": True})
+        failed_after = [
+            ch
+            for ch in pending_after["channels"]
+            if ch["state"]["state_name"] == "CLOSED"
+        ]
+        assert (
+            len(failed_after) >= 1
+        ), "Abandoned channel should still appear as CLOSED in only_pending=true on fiber3 after restart"
+
+        for fc in failed_after:
+            assert fc["state"]["state_flags"] in (
+                "ABANDONED",
+                "FUNDING_ABORTED",
+            ), f"Unexpected close flag after restart: {fc['state']['state_flags']}"
+            assert (
+                fc["failure_detail"] is not None
+            ), "failure_detail must not be None for abandoned channel after restart"
+            assert (
+                isinstance(fc["failure_detail"], str) and len(fc["failure_detail"]) > 0
+            ), "failure_detail must be a non-empty string after restart"
+
+        # Verify same channel is present and failure_detail is preserved
+        failed_channel_ids_after = [fc["channel_id"] for fc in failed_after]
+        assert (
+            failed_channel_id_before in failed_channel_ids_after
+        ), "The same abandoned channel should be present after restart"
+        matching_channel = next(
+            (fc for fc in failed_after if fc["channel_id"] == failed_channel_id_before),
+            None,
+        )
+        assert (
+            matching_channel is not None
+        ), "Abandoned channel should be found by channel_id after restart"
+        assert matching_channel["failure_detail"] == failure_detail_before, (
+            f"failure_detail should be preserved after restart. "
+            f"Before: {failure_detail_before}, After: {matching_channel['failure_detail']}"
+        )

--- a/test_cases/fiber/devnet/list_channels/test_only_pending.py
+++ b/test_cases/fiber/devnet/list_channels/test_only_pending.py
@@ -158,6 +158,74 @@ class TestListChannelsOnlyPending(FiberTest):
         ]
         assert len(ready_in_pending) == 0
 
+    def test_only_pending_initiator_sees_outbound_pending_channel(self):
+        """
+        When fiber1 opens a channel with a funding amount below the auto-accept
+        threshold, the channel is not auto-accepted and requires manual
+        `accept_channel` from fiber2. Before acceptance, the initiator (fiber1)
+        should also be able to see its own pending outbound channel via
+        `list_channels(only_pending=true)`.
+
+        This complements test_only_pending_shows_inbound_waiting_for_accept which
+        only verifies the acceptor (fiber2) side.
+
+        Steps:
+        1. Get the auto-accept min funding amount from fiber2.
+        2. fiber1 opens a channel with funding_amount below the threshold.
+        3. fiber1 calls list_channels(only_pending=true).
+        4. Verify the pending outbound channel is returned on the initiator side
+           (fiber1) with is_acceptor=false.
+        5. fiber2 calls list_channels(only_pending=true).
+        6. Verify fiber2 also sees the pending inbound channel.
+        """
+        # Step 1: Get auto-accept threshold
+        node_info = self.fiber2.get_client().node_info()
+        auto_accept_min = int(
+            node_info["open_channel_auto_accept_min_ckb_funding_amount"], 16
+        )
+
+        # Step 2: Open channel below threshold (requires manual accept)
+        self.fiber1.get_client().open_channel(
+            {
+                "peer_id": self.fiber2.get_peer_id(),
+                "funding_amount": hex(auto_accept_min - 1),
+                "public": True,
+            }
+        )
+        time.sleep(2)
+
+        # Step 3: On the initiator (fiber1), list_channels with only_pending=true
+        pending_channels_fiber1 = self.fiber1.get_client().list_channels(
+            {"only_pending": True}
+        )
+
+        # Step 4: Verify the outbound pending channel appears on the initiator side
+        outbound_pending = [
+            ch
+            for ch in pending_channels_fiber1["channels"]
+            if ch["is_acceptor"] is False
+        ]
+        assert len(outbound_pending) >= 1, (
+            "Initiator (fiber1) should see its own pending outbound channel "
+            "in list_channels(only_pending=true) before peer accepts"
+        )
+
+        # Step 5: On the acceptor (fiber2), list_channels with only_pending=true
+        pending_channels_fiber2 = self.fiber2.get_client().list_channels(
+            {"only_pending": True}
+        )
+
+        # Step 6: Verify fiber2 also sees the pending inbound channel
+        inbound_pending = [
+            ch
+            for ch in pending_channels_fiber2["channels"]
+            if ch["is_acceptor"] is True
+        ]
+        assert len(inbound_pending) >= 1, (
+            "Acceptor (fiber2) should see the pending inbound channel "
+            "in list_channels(only_pending=true)"
+        )
+
     def test_only_pending_shows_failed_channel_with_failure_detail(self):
         """
         When an outbound channel opening fails (e.g. peer disconnects during


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that adds coverage around `list_channels` filtering and failure reporting; no production logic is modified.
> 
> **Overview**
> Adds a new devnet integration test suite `test_only_pending.py` covering the `list_channels` RPC’s new `only_pending` flag.
> 
> The tests assert that `only_pending=true` returns *only* pre-ready and failed-opening channels (including `failure_detail`), supports `peer_id` filtering, avoids duplicate `channel_id` entries/balance inconsistencies before acceptance, and remains correct across disconnects and node restarts while preserving default `list_channels` behavior when `only_pending` is omitted/false.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7e9a94cb4e224eceb6464438b188a3f0b63692b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->