### PR TITLE
test: add funding retry integration tests for PR#1213 (issue #1189)

### DIFF
--- a/framework/ckb_rpc_proxy.py
+++ b/framework/ckb_rpc_proxy.py
@@ -179,12 +179,16 @@ class CkbRpcProxy:
                     if proxy_ref._auto_blocked:
                         self._send_rst(self.connection)
                         return
-                    if proxy_ref._auto_block_method and method == proxy_ref._auto_block_method:
+                    if (
+                        proxy_ref._auto_block_method
+                        and method == proxy_ref._auto_block_method
+                    ):
                         proxy_ref._auto_block_method = None
                         proxy_ref._auto_blocked = True
                         logger.info(
                             "CKB RPC proxy AUTO-BLOCK triggered by '%s' "
-                            "— closing listening socket", method
+                            "— closing listening socket",
+                            method,
                         )
                         try:
                             proxy_ref._server.socket.close()
@@ -197,14 +201,16 @@ class CkbRpcProxy:
                 with proxy_ref._lock:
                     if method in proxy_ref._blocked_methods:
                         logger.info("CKB RPC proxy BLOCKING method '%s'", method)
-                        err_body = json.dumps({
-                            "jsonrpc": "2.0",
-                            "id": req_id,
-                            "error": {
-                                "code": -1,
-                                "message": "CKB RPC proxy: method blocked",
-                            },
-                        }).encode()
+                        err_body = json.dumps(
+                            {
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {
+                                    "code": -1,
+                                    "message": "CKB RPC proxy: method blocked",
+                                },
+                            }
+                        ).encode()
                         self.send_response(200)
                         self.send_header("Content-Type", "application/json")
                         self.end_headers()
@@ -217,7 +223,8 @@ class CkbRpcProxy:
                         if proxy_ref._forwarded_count >= proxy_ref._block_after:
                             logger.info(
                                 "CKB RPC proxy BLOCKED request #%d (method=%s, limit=%d)",
-                                proxy_ref._forwarded_count + 1, method,
+                                proxy_ref._forwarded_count + 1,
+                                method,
                                 proxy_ref._block_after,
                             )
                             self._send_rst(self.connection)
@@ -259,9 +266,7 @@ class CkbRpcProxy:
         if self.port is None:
             self.port = actual_port
         self.url = f"http://127.0.0.1:{self.port}"
-        self._thread = threading.Thread(
-            target=self._server.serve_forever, daemon=True
-        )
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()
         logger.info("CKB RPC proxy started on %s → %s", self.url, self.target_url)
 

--- a/framework/ckb_rpc_proxy.py
+++ b/framework/ckb_rpc_proxy.py
@@ -45,6 +45,7 @@ class CkbRpcProxy:
         self._blocked_methods = set()
         self._block_after = None  # block after N forwarded requests
         self._forwarded_count = 0
+        self._forwarded_total = 0
         self._notify_method = None
         self._notify_event = threading.Event()
         self._auto_block_method = None
@@ -65,8 +66,9 @@ class CkbRpcProxy:
     def block_methods(self, methods):
         """Block specific JSON-RPC methods by name.
 
-        Requests with a matching ``method`` field get an immediate TCP RST.
-        All other RPC methods are forwarded normally.
+        Requests with a matching ``method`` field receive an HTTP 200
+        response containing a JSON-RPC error object instead of being
+        forwarded. All other RPC methods are forwarded normally.
         """
         with self._lock:
             self._blocked_methods = set(methods)
@@ -82,7 +84,8 @@ class CkbRpcProxy:
         """Allow exactly *n* more requests through, then auto-block.
 
         After *n* requests have been forwarded, all subsequent requests
-        get a JSON-RPC error response until ``resume()`` is called.
+        get an immediate connection reset (TCP RST) until ``resume()``
+        is called.
         """
         with self._lock:
             self._block_after = n
@@ -237,7 +240,8 @@ class CkbRpcProxy:
                         proxy_ref._notify_method = None
                         proxy_ref._notify_event.set()
                         logger.info("CKB RPC proxy TRIGGER: saw method '%s'", method)
-                    _cnt = proxy_ref._forwarded_count
+                    proxy_ref._forwarded_total += 1
+                    _cnt = proxy_ref._forwarded_total
 
                 logger.info("CKB RPC proxy forwarding #%d: %s", _cnt, method or "?")
 
@@ -263,8 +267,7 @@ class CkbRpcProxy:
 
         self._server = http.server.HTTPServer(("127.0.0.1", port), _Handler)
         actual_port = self._server.server_address[1]
-        if self.port is None:
-            self.port = actual_port
+        self.port = actual_port
         self.url = f"http://127.0.0.1:{self.port}"
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()

--- a/framework/ckb_rpc_proxy.py
+++ b/framework/ckb_rpc_proxy.py
@@ -1,0 +1,302 @@
+"""
+A simple HTTP reverse proxy for CKB RPC that can be programmatically
+toggled between forwarding and blocking modes.
+
+When blocked, the proxy shuts down its listening socket so that clients
+receive "Connection refused" errors — the same class of transient network
+error that testnet.ckbapp.dev produced in issue #1189.
+
+Additionally supports ``reject_next(n)`` which accepts TCP connections
+but immediately closes them without sending any HTTP response, simulating
+the "Connection reset by peer" error from the original issue.
+"""
+
+import http.server
+import json
+import socket
+import struct
+import threading
+import urllib.request
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CkbRpcProxy:
+    """HTTP reverse proxy sitting between Fiber nodes and CKB RPC.
+
+    Usage:
+        proxy = CkbRpcProxy("http://127.0.0.1:8114")
+        proxy.start()           # pick a random free port
+        print(proxy.url)        # e.g. "http://127.0.0.1:54321"
+        proxy.block()           # stop accepting connections
+        proxy.unblock()         # resume forwarding
+        proxy.reject_next(3)    # next 3 requests get connection-reset
+        proxy.stop()            # tear down
+    """
+
+    def __init__(self, target_url: str):
+        self.target_url = target_url
+        self._server = None
+        self._thread = None
+        self.port = None
+        self.url = None
+        self._reject_remaining = 0
+        self._blocked_methods = set()
+        self._block_after = None  # block after N forwarded requests
+        self._forwarded_count = 0
+        self._notify_method = None
+        self._notify_event = threading.Event()
+        self._auto_block_method = None
+        self._auto_blocked = False
+        self._lock = threading.Lock()
+
+    def reject_next(self, n: int):
+        """Make the next *n* requests get an immediate connection reset.
+
+        The proxy stays listening (port is open), but closes the TCP
+        connection without sending any HTTP response.  After *n* requests
+        are rejected, normal forwarding resumes automatically.
+        """
+        with self._lock:
+            self._reject_remaining = n
+        logger.info("CKB RPC proxy will reject next %d requests", n)
+
+    def block_methods(self, methods):
+        """Block specific JSON-RPC methods by name.
+
+        Requests with a matching ``method`` field get an immediate TCP RST.
+        All other RPC methods are forwarded normally.
+        """
+        with self._lock:
+            self._blocked_methods = set(methods)
+        logger.info("CKB RPC proxy blocking methods: %s", methods)
+
+    def unblock_methods(self):
+        """Clear method-level blocking; resume forwarding all methods."""
+        with self._lock:
+            self._blocked_methods.clear()
+        logger.info("CKB RPC proxy unblocked all methods")
+
+    def block_after(self, n: int):
+        """Allow exactly *n* more requests through, then auto-block.
+
+        After *n* requests have been forwarded, all subsequent requests
+        get a JSON-RPC error response until ``resume()`` is called.
+        """
+        with self._lock:
+            self._block_after = n
+            self._forwarded_count = 0
+        logger.info("CKB RPC proxy will block after %d requests", n)
+
+    def resume(self):
+        """Clear block_after state; resume normal forwarding."""
+        with self._lock:
+            self._block_after = None
+        logger.info("CKB RPC proxy resumed normal forwarding")
+
+    def notify_on_method(self, method_name: str):
+        """Set up notification: when *method_name* is seen, set event.
+
+        The request is still forwarded normally, but the event is set
+        so the test thread can react (e.g. call ``block()``).
+        """
+        with self._lock:
+            self._notify_method = method_name
+            self._notify_event.clear()
+        logger.info("CKB RPC proxy will notify on method '%s'", method_name)
+
+    def wait_for_method(self, timeout: float = 30) -> bool:
+        """Block until the notify method is seen. Returns True if seen."""
+        return self._notify_event.wait(timeout=timeout)
+
+    def auto_block_on_method(self, method_name: str):
+        """When *method_name* is first seen, immediately close the listening
+        socket from within the handler thread.
+
+        This produces "Connection refused" for ALL subsequent TCP connections
+        — the same error mode as ``block()``, but triggered deterministically
+        without timing dependencies.  The current request gets a TCP RST,
+        and ALL later requests fail at the TCP level.
+
+        Call ``unblock()`` to restart the proxy afterwards.
+        """
+        with self._lock:
+            self._auto_block_method = method_name
+            self._auto_blocked = False
+        logger.info("CKB RPC proxy will auto-block on method '%s'", method_name)
+
+    @property
+    def auto_blocked(self) -> bool:
+        with self._lock:
+            return self._auto_blocked
+
+    def start(self, port: int = 0):
+        """Start (or restart) the proxy on *port* (0 = auto-assign)."""
+        proxy_ref = self
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            @staticmethod
+            def _send_rst(conn):
+                """Send TCP RST (Connection reset by peer) instead of graceful FIN."""
+                try:
+                    conn.setsockopt(
+                        socket.SOL_SOCKET,
+                        socket.SO_LINGER,
+                        struct.pack("ii", 1, 0),
+                    )
+                    conn.close()
+                except Exception:
+                    pass
+
+            @staticmethod
+            def _parse_rpc(body):
+                """Parse JSON-RPC body, returning (method, id)."""
+                try:
+                    rpc = json.loads(body)
+                    return rpc.get("method", ""), rpc.get("id", 0)
+                except Exception:
+                    return "", 0
+
+            def do_POST(self):
+                # --- Pre-body check: reject_next (no need to read body) ---
+                with proxy_ref._lock:
+                    if proxy_ref._reject_remaining > 0:
+                        proxy_ref._reject_remaining -= 1
+                        logger.info(
+                            "CKB RPC proxy REJECTING request (%d remaining)",
+                            proxy_ref._reject_remaining,
+                        )
+                        self._send_rst(self.connection)
+                        return
+
+                content_length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(content_length)
+                method, req_id = self._parse_rpc(body)
+
+                # --- auto_block: close listening socket on trigger method ---
+                with proxy_ref._lock:
+                    if proxy_ref._auto_blocked:
+                        self._send_rst(self.connection)
+                        return
+                    if proxy_ref._auto_block_method and method == proxy_ref._auto_block_method:
+                        proxy_ref._auto_block_method = None
+                        proxy_ref._auto_blocked = True
+                        logger.info(
+                            "CKB RPC proxy AUTO-BLOCK triggered by '%s' "
+                            "— closing listening socket", method
+                        )
+                        try:
+                            proxy_ref._server.socket.close()
+                        except Exception:
+                            pass
+                        self._send_rst(self.connection)
+                        return
+
+                # --- block_methods: return JSON-RPC error for specific methods ---
+                with proxy_ref._lock:
+                    if method in proxy_ref._blocked_methods:
+                        logger.info("CKB RPC proxy BLOCKING method '%s'", method)
+                        err_body = json.dumps({
+                            "jsonrpc": "2.0",
+                            "id": req_id,
+                            "error": {
+                                "code": -1,
+                                "message": "CKB RPC proxy: method blocked",
+                            },
+                        }).encode()
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(err_body)
+                        return
+
+                # --- block_after: RST after N forwarded requests ---
+                with proxy_ref._lock:
+                    if proxy_ref._block_after is not None:
+                        if proxy_ref._forwarded_count >= proxy_ref._block_after:
+                            logger.info(
+                                "CKB RPC proxy BLOCKED request #%d (method=%s, limit=%d)",
+                                proxy_ref._forwarded_count + 1, method,
+                                proxy_ref._block_after,
+                            )
+                            self._send_rst(self.connection)
+                            return
+                        proxy_ref._forwarded_count += 1
+
+                # --- Notify trigger (one-shot) ---
+                with proxy_ref._lock:
+                    if proxy_ref._notify_method and method == proxy_ref._notify_method:
+                        proxy_ref._notify_method = None
+                        proxy_ref._notify_event.set()
+                        logger.info("CKB RPC proxy TRIGGER: saw method '%s'", method)
+                    _cnt = proxy_ref._forwarded_count
+
+                logger.info("CKB RPC proxy forwarding #%d: %s", _cnt, method or "?")
+
+                # --- Forward to upstream CKB RPC ---
+                try:
+                    req = urllib.request.Request(
+                        proxy_ref.target_url,
+                        data=body,
+                        headers={"Content-Type": "application/json"},
+                    )
+                    with urllib.request.urlopen(req, timeout=30) as resp:
+                        resp_body = resp.read()
+                        self.send_response(resp.status)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(resp_body)
+                except Exception as e:
+                    logger.debug("Proxy forward error: %s", e)
+                    self.send_error(502, "Proxy forwarding error")
+
+            def log_message(self, format, *args):
+                pass  # suppress per-request logs
+
+        self._server = http.server.HTTPServer(("127.0.0.1", port), _Handler)
+        actual_port = self._server.server_address[1]
+        if self.port is None:
+            self.port = actual_port
+        self.url = f"http://127.0.0.1:{self.port}"
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, daemon=True
+        )
+        self._thread.start()
+        logger.info("CKB RPC proxy started on %s → %s", self.url, self.target_url)
+
+    def block(self):
+        """Stop accepting connections — clients will get *Connection refused*."""
+        if self._server:
+            self._server.shutdown()
+            self._server.server_close()
+            if self._thread:
+                self._thread.join(timeout=5)
+            self._server = None
+            self._thread = None
+            logger.info("CKB RPC proxy BLOCKED (port %s closed)", self.port)
+
+    def unblock(self):
+        """Re-open the proxy on the same port."""
+        with self._lock:
+            self._auto_blocked = False
+            self._auto_block_method = None
+        if self._server is not None:
+            # Server object exists but socket may have been closed by auto_block
+            try:
+                self._server.shutdown()
+                self._server.server_close()
+            except Exception:
+                pass
+            if self._thread:
+                self._thread.join(timeout=5)
+            self._server = None
+            self._thread = None
+        self.start(port=self.port)
+        logger.info("CKB RPC proxy UNBLOCKED (port %s re-opened)", self.port)
+
+    def stop(self):
+        """Tear everything down."""
+        self.block()
+        self.port = None
+        self.url = None

--- a/test_cases/fiber/devnet/open_channel/test_funding_retry.py
+++ b/test_cases/fiber/devnet/open_channel/test_funding_retry.py
@@ -129,9 +129,9 @@ class TestFundingRetry(FiberTest):
         """Assert that retry messages appear in the Fiber node log."""
         log = self._read_fiber_log(fiber)
         # PR-1213 logs: "Temporary {operation} error, scheduling retry"
-        assert "scheduling retry" in log.lower() or "retry" in log.lower(), (
-            f"Expected retry log messages for '{label}' in {fiber.tmp_path}/node.log"
-        )
+        assert (
+            "scheduling retry" in log.lower() or "retry" in log.lower()
+        ), f"Expected retry log messages for '{label}' in {fiber.tmp_path}/node.log"
 
     # ------------------------------------------------------------------
     # Test Cases
@@ -210,9 +210,9 @@ class TestFundingRetry(FiberTest):
         )
         if len(channels["channels"]) > 0:
             state = channels["channels"][0]["state"]["state_name"]
-            assert state != "ChannelReady", (
-                f"Channel should have been aborted but is in state: {state}"
-            )
+            assert (
+                state != "ChannelReady"
+            ), f"Channel should have been aborted but is in state: {state}"
         # If no channels at all, that's also acceptable (fully cleaned up)
 
     def test_open_channel_normal_via_proxy(self):
@@ -221,9 +221,7 @@ class TestFundingRetry(FiberTest):
         Verifies the proxy does not interfere with normal channel establishment.
         """
         # Proxy is forwarding by default — just open a channel normally
-        self.open_channel(
-            self.fiber1, self.fiber2, 200 * 100000000, 100 * 100000000
-        )
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 100 * 100000000)
         # If we get here, the channel opened successfully through the proxy
         channels = self.fiber1.get_client().list_channels(
             {"pubkey": self.fiber2.get_pubkey()}
@@ -386,6 +384,6 @@ class TestFundingRetry(FiberTest):
         log1 = self._read_fiber_log(self.fiber1)
         log2 = self._read_fiber_log(self.fiber2)
         combined = (log1 + log2).lower()
-        assert "scheduling retry" in combined or "retry" in combined, (
-            "Expected retry log messages in fiber node logs"
-        )
+        assert (
+            "scheduling retry" in combined or "retry" in combined
+        ), "Expected retry log messages in fiber node logs"

--- a/test_cases/fiber/devnet/open_channel/test_funding_retry.py
+++ b/test_cases/fiber/devnet/open_channel/test_funding_retry.py
@@ -24,8 +24,6 @@ Approach:
 """
 
 import time
-import threading
-import pytest
 
 from framework.basic_fiber import FiberTest
 from framework.ckb_rpc_proxy import CkbRpcProxy
@@ -109,8 +107,9 @@ class TestFundingRetry(FiberTest):
         self.logger.debug(f"\nSetting up method: {method.__name__}")
 
     def teardown_method(self, method):
-        if self.proxy:
-            self.proxy.stop()
+        proxy = getattr(self, "proxy", None)
+        if proxy:
+            proxy.stop()
         super().teardown_method(method)
 
     # ------------------------------------------------------------------
@@ -128,10 +127,11 @@ class TestFundingRetry(FiberTest):
     def _assert_retry_in_logs(self, fiber, label="fund channel"):
         """Assert that retry messages appear in the Fiber node log."""
         log = self._read_fiber_log(fiber)
+        log_lower = log.lower()
         # PR-1213 logs: "Temporary {operation} error, scheduling retry"
         assert (
-            "scheduling retry" in log.lower() or "retry" in log.lower()
-        ), f"Expected retry log messages for '{label}' in {fiber.tmp_path}/node.log"
+            "scheduling retry" in log_lower
+        ), f"Expected 'scheduling retry' in {fiber.tmp_path}/node.log"
 
     # ------------------------------------------------------------------
     # Test Cases
@@ -385,5 +385,5 @@ class TestFundingRetry(FiberTest):
         log2 = self._read_fiber_log(self.fiber2)
         combined = (log1 + log2).lower()
         assert (
-            "scheduling retry" in combined or "retry" in combined
-        ), "Expected retry log messages in fiber node logs"
+            "scheduling retry" in combined
+        ), "Expected 'scheduling retry' in fiber node logs"

--- a/test_cases/fiber/devnet/open_channel/test_funding_retry.py
+++ b/test_cases/fiber/devnet/open_channel/test_funding_retry.py
@@ -1,0 +1,391 @@
+"""
+PR-1213: feat: funding retry
+https://github.com/nervosnetwork/fiber/pull/1213
+
+Test coverage for channel funding retry on transient CKB RPC errors.
+Verifies the fix for issue #1189 where transient HTTP errors during
+cell collection or transaction signing permanently aborted channels.
+
+Issue #1189 identifies three root causes:
+  1. is_temporary() didn't classify CkbTxBuilderError/CkbTxUnlockError
+     as temporary when they wrap transient HTTP errors.
+  2. Even temporary errors only skipped abort_funding without scheduling
+     a retry, leaving channels stalled forever.
+  3. SignFundingTx unconditionally aborted on any error without checking
+     is_temporary().
+
+Approach:
+    A CKB RPC proxy sits between Fiber nodes and the CKB devnet node.
+    - block()/unblock(): shuts down the proxy port entirely → "Connection
+      refused" errors.
+    - reject_next(n): keeps the port open but closes TCP connections
+      without sending a response → "Connection reset by peer" errors,
+      matching the original testnet.ckbapp.dev failure mode.
+"""
+
+import time
+import threading
+import pytest
+
+from framework.basic_fiber import FiberTest
+from framework.ckb_rpc_proxy import CkbRpcProxy
+from framework.config import DEFAULT_MIN_DEPOSIT_CKB
+
+
+class TestFundingRetry(FiberTest):
+    """Test funding retry on transient CKB RPC failures (PR-1213)."""
+
+    proxy: CkbRpcProxy
+
+    def setup_method(self, method):
+        """Override: insert CKB RPC proxy before starting Fiber nodes."""
+        self.did_pass = None
+        self.beginNum = hex(self.node.getClient().get_tip_block_number())
+        self.fibers = []
+        self.new_fibers = []
+
+        # --- Start CKB RPC proxy ---
+        self.proxy = CkbRpcProxy(self.node.rpcUrl)
+        self.proxy.start()
+
+        from framework.test_fiber import Fiber
+
+        self.fiber1 = Fiber.init_by_port(
+            self.fiber_version,
+            self.account1_private_key,
+            "fiber/node1",
+            "8228",
+            "8227",
+        )
+        self.fiber2 = Fiber.init_by_port(
+            self.fiber_version,
+            self.account2_private_key,
+            "fiber/node2",
+            "8229",
+            "8230",
+        )
+        self.fibers.append(self.fiber1)
+        self.fibers.append(self.fiber2)
+
+        from framework.helper.udt_contract import UdtContract, issue_udt_tx
+        from framework.basic_fiber import XUDT_TX_HASH
+
+        self.udtContract = UdtContract(XUDT_TX_HASH, 0)
+        deploy_hash, deploy_index = self.udtContract.get_deploy_hash_and_index()
+
+        self.node.getClient().clear_tx_pool()
+        for i in range(5):
+            self.Miner.miner_with_version(self.node, "0x0")
+        tx_hash = issue_udt_tx(
+            self.udtContract,
+            self.node.rpcUrl,
+            self.fiber1.account_private,
+            self.fiber1.account_private,
+            1000 * 100000000,
+        )
+        self.Miner.miner_until_tx_committed(self.node, tx_hash)
+        self.node.start_miner()
+
+        # --- Key difference: Fiber nodes use the PROXY URL, not the direct CKB URL ---
+        update_config = {
+            "ckb_rpc_url": self.proxy.url,
+            "ckb_udt_whitelist": True,
+            "xudt_script_code_hash": self.Contract.get_ckb_contract_codehash(
+                deploy_hash, deploy_index, True, self.node.rpcUrl
+            ),
+            "xudt_cell_deps_tx_hash": deploy_hash,
+            "xudt_cell_deps_index": deploy_index,
+        }
+        update_config.update(self.start_fiber_config)
+
+        self.fiber1.prepare(update_config=update_config)
+        self.fiber1.start(fnn_log_level=self.fnn_log_level)
+
+        self.fiber2.prepare(update_config=update_config)
+        self.fiber2.start(fnn_log_level=self.fnn_log_level)
+
+        self.fiber1.connect_peer(self.fiber2)
+        time.sleep(1)
+        self.logger.debug(f"\nSetting up method: {method.__name__}")
+
+    def teardown_method(self, method):
+        if self.proxy:
+            self.proxy.stop()
+        super().teardown_method(method)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _read_fiber_log(self, fiber) -> str:
+        """Read a Fiber node's log file."""
+        log_path = f"{fiber.tmp_path}/node.log"
+        try:
+            with open(log_path, "r") as f:
+                return f.read()
+        except FileNotFoundError:
+            return ""
+
+    def _assert_retry_in_logs(self, fiber, label="fund channel"):
+        """Assert that retry messages appear in the Fiber node log."""
+        log = self._read_fiber_log(fiber)
+        # PR-1213 logs: "Temporary {operation} error, scheduling retry"
+        assert "scheduling retry" in log.lower() or "retry" in log.lower(), (
+            f"Expected retry log messages for '{label}' in {fiber.tmp_path}/node.log"
+        )
+
+    # ------------------------------------------------------------------
+    # Test Cases
+    # ------------------------------------------------------------------
+    def test_open_channel_succeeds_after_transient_ckb_rpc_failure(self):
+        """
+        Core test: block CKB RPC proxy, open channel, unblock after a few
+        seconds.  The retry mechanism should allow the channel to eventually
+        reach ChannelReady.
+
+        Timeline:
+          t=0s   block proxy + call open_channel
+          t=3s   unblock proxy (after 1-2 retry failures)
+          t≈15s  channel reaches ChannelReady via retry
+        """
+        # Block CKB RPC *before* opening the channel
+        self.proxy.block()
+
+        # open_channel RPC goes to Fiber (not CKB), so it succeeds immediately
+        self.fiber1.get_client().open_channel(
+            {
+                "pubkey": self.fiber2.get_pubkey(),
+                "funding_amount": hex(200 * 100000000 + DEFAULT_MIN_DEPOSIT_CKB),
+                "public": True,
+                "tlc_fee_proportional_millionths": "0x4B0",
+            }
+        )
+
+        # Keep proxy blocked for 3 seconds to let 1-2 retry attempts fail
+        time.sleep(3)
+
+        # Unblock — next retry should pick up and succeed
+        self.proxy.unblock()
+
+        # Wait for channel to become ready
+        self.wait_for_channel_state(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            "ChannelReady",
+            timeout=30,
+        )
+
+        # Verify retries happened by checking logs
+        self._assert_retry_in_logs(self.fiber1)
+
+    def test_channel_aborted_after_retry_exhausted(self):
+        """
+        Boundary test: keep CKB RPC blocked until all 5 retry attempts are
+        exhausted.  The channel should transition to a closed/aborted state.
+
+        Retry timing: 2s + 4s + 8s + 16s = 30s total before 5th attempt aborts.
+        We block for 35s to be safe.
+        """
+        self.proxy.block()
+
+        self.fiber1.get_client().open_channel(
+            {
+                "pubkey": self.fiber2.get_pubkey(),
+                "funding_amount": hex(200 * 100000000 + DEFAULT_MIN_DEPOSIT_CKB),
+                "public": True,
+                "tlc_fee_proportional_millionths": "0x4B0",
+            }
+        )
+
+        # Wait long enough for all retries to be exhausted
+        # Attempts: 1(+0s), 2(+2s), 3(+4s), 4(+8s), 5(+16s) → ~30s total
+        time.sleep(35)
+
+        # Unblock now (too late — retries should be exhausted)
+        self.proxy.unblock()
+        time.sleep(3)
+
+        # Channel should NOT be in ChannelReady; it should be closed/absent
+        channels = self.fiber1.get_client().list_channels(
+            {"pubkey": self.fiber2.get_pubkey(), "include_closed": True}
+        )
+        if len(channels["channels"]) > 0:
+            state = channels["channels"][0]["state"]["state_name"]
+            assert state != "ChannelReady", (
+                f"Channel should have been aborted but is in state: {state}"
+            )
+        # If no channels at all, that's also acceptable (fully cleaned up)
+
+    def test_open_channel_normal_via_proxy(self):
+        """
+        Control test: proxy in forwarding mode (no blocking).
+        Verifies the proxy does not interfere with normal channel establishment.
+        """
+        # Proxy is forwarding by default — just open a channel normally
+        self.open_channel(
+            self.fiber1, self.fiber2, 200 * 100000000, 100 * 100000000
+        )
+        # If we get here, the channel opened successfully through the proxy
+        channels = self.fiber1.get_client().list_channels(
+            {"pubkey": self.fiber2.get_pubkey()}
+        )
+        assert len(channels["channels"]) > 0
+        assert channels["channels"][0]["state"]["state_name"] == "ChannelReady"
+
+    # ------------------------------------------------------------------
+    # Issue #1189, Failure 1: only one side's CKB RPC fails
+    # ------------------------------------------------------------------
+    def test_only_one_side_ckb_rpc_fails(self):
+        """
+        Issue #1189 Failure 1: acceptor-side cell collector HTTP failure.
+
+        Setup:
+          - fiber1 uses the shared proxy (will be blocked → CKB RPC unavailable)
+          - fiber3 is started via start_new_fiber → uses direct CKB RPC URL
+            (no proxy, always available)
+          - fiber1 opens channel to fiber3
+
+        When the proxy is blocked, only fiber1's UpdateChannelFunding fails.
+        fiber3's UpdateChannelFunding succeeds through the direct CKB
+        connection. After the proxy is unblocked, fiber1's retry succeeds
+        and the channel reaches ChannelReady.
+
+        This verifies asymmetric failure handling — the channel protocol
+        tolerates one side being temporarily slower due to RPC retries.
+        """
+        # fiber3 uses direct CKB URL (start_new_fiber does NOT use the proxy)
+        fiber3 = self.start_new_fiber(self.generate_account(10000))
+        self.fiber1.connect_peer(fiber3)
+        time.sleep(1)
+
+        # Block fiber1's CKB RPC
+        self.proxy.block()
+
+        self.fiber1.get_client().open_channel(
+            {
+                "pubkey": fiber3.get_pubkey(),
+                "funding_amount": hex(200 * 100000000 + DEFAULT_MIN_DEPOSIT_CKB),
+                "public": True,
+                "tlc_fee_proportional_millionths": "0x4B0",
+            }
+        )
+
+        # Let 1-2 retry attempts fail
+        time.sleep(3)
+
+        # Unblock — fiber1's next retry succeeds
+        self.proxy.unblock()
+
+        self.wait_for_channel_state(
+            self.fiber1.get_client(),
+            fiber3.get_pubkey(),
+            "ChannelReady",
+            timeout=30,
+        )
+
+        # Verify retry happened on fiber1's side
+        self._assert_retry_in_logs(self.fiber1)
+
+    # ------------------------------------------------------------------
+    # Issue #1189, Issue 3: SignFundingTx retry
+    # ------------------------------------------------------------------
+    def test_sign_phase_retry_via_mid_flow_block(self):
+        """
+        Issue #1189 Issue 3: SignFundingTx used to unconditionally abort
+        on any error without checking is_temporary().
+
+        Strategy: use ``auto_block_on_method("get_transaction")`` so the
+        proxy automatically closes its listening socket (→ Connection refused)
+        the instant it sees a ``get_transaction`` RPC call.  Cell collection
+        RPCs (get_cells, get_live_cell, etc.) are forwarded normally, but
+        the first ``get_transaction`` — used for signing / cell dep
+        resolution — triggers immediate port shutdown.
+
+        This is deterministic and has no timing dependency:
+          - Cell collection succeeds (earlier RPCs forwarded)
+          - The get_transaction call (and all subsequent calls) fail with
+            Connection refused
+          - Fixed version: retries and recovers → ChannelReady
+          - Buggy version: unconditionally aborts → never ChannelReady
+        """
+        # Arm the auto-block trigger
+        self.proxy.auto_block_on_method("get_transaction")
+
+        self.fiber1.get_client().open_channel(
+            {
+                "pubkey": self.fiber2.get_pubkey(),
+                "funding_amount": hex(200 * 100000000 + DEFAULT_MIN_DEPOSIT_CKB),
+                "public": True,
+                "tlc_fee_proportional_millionths": "0x4B0",
+            }
+        )
+
+        # Wait for auto-block to trigger and sign retries to fail
+        for _ in range(10):
+            if self.proxy.auto_blocked:
+                break
+            time.sleep(0.5)
+        assert self.proxy.auto_blocked, "auto_block_on_method did not trigger"
+
+        # Keep blocked for a few seconds to let retry attempts fail
+        time.sleep(3)
+
+        # Unblock — next retry should succeed
+        self.proxy.unblock()
+
+        # Channel should reach ChannelReady via retry
+        self.wait_for_channel_state(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            "ChannelReady",
+            timeout=30,
+        )
+
+    # ------------------------------------------------------------------
+    # Issue #1189 reproduction: connection-reset mid-flow
+    # ------------------------------------------------------------------
+    def test_connection_reset_mid_flow(self):
+        """
+        Simulates the exact failure mode from Issue #1189: the CKB RPC
+        endpoint resets TCP connections mid-flow (without closing the port).
+
+        Uses reject_next(n) which keeps the proxy port open but closes
+        TCP connections immediately, producing "Connection reset by peer"
+        errors — exactly matching the testnet.ckbapp.dev failure.
+
+        Strategy: set reject_next BEFORE opening the channel so the first
+        CKB RPC calls for funding/signing are guaranteed to be rejected.
+        Both fiber1 and fiber2 use the proxy, so we need enough rejects
+        to cover both sides' calls. After the rejects are consumed, the
+        proxy auto-resumes normal forwarding.
+        """
+        # Set rejections BEFORE opening channel to ensure funding CKB calls
+        # are hit. Use a small count (2) so retries can succeed after the
+        # rejections are consumed. Both nodes share the proxy, so 2 rejects
+        # will be consumed quickly by the first funding CKB call(s).
+        self.proxy.reject_next(2)
+
+        self.fiber1.get_client().open_channel(
+            {
+                "pubkey": self.fiber2.get_pubkey(),
+                "funding_amount": hex(200 * 100000000 + DEFAULT_MIN_DEPOSIT_CKB),
+                "public": True,
+                "tlc_fee_proportional_millionths": "0x4B0",
+            }
+        )
+
+        # Channel should recover via retry and reach ChannelReady
+        # (after rejections are consumed, proxy auto-resumes forwarding)
+        self.wait_for_channel_state(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            "ChannelReady",
+            timeout=30,
+        )
+
+        # Verify retries happened — check both nodes since both use the proxy
+        log1 = self._read_fiber_log(self.fiber1)
+        log2 = self._read_fiber_log(self.fiber2)
+        combined = (log1 + log2).lower()
+        assert "scheduling retry" in combined or "retry" in combined, (
+            "Expected retry log messages in fiber node logs"
+        )


### PR DESCRIPTION
## Summary

为 Fiber PR [nervosnetwork/fiber#1213](https://github.com/nervosnetwork/fiber/pull/1213) 编写集成测试，验证 channel funding 阶段遇到瞬时 CKB RPC 错误时的重试机制。

该 PR 修复了 [issue #1189](https://github.com/nervosnetwork/fiber/issues/1189)：瞬时 HTTP 错误（Connection refused / Connection reset）导致 channel 永久 abort，无法恢复。

## 新增文件

### `framework/ckb_rpc_proxy.py`
CKB RPC 反向代理，用于在 Fiber 节点和 CKB RPC 之间注入故障：
- `block()` / `unblock()` — 关闭/重开代理端口，产生 Connection refused
- `reject_next(n)` — 保持端口开放但立即 RST TCP 连接，模拟 Connection reset by peer
- `auto_block_on_method(name)` — 当看到指定 RPC 方法时自动关闭端口，确定性地触发签名阶段失败

### `test_cases/fiber/devnet/open_channel/test_funding_retry.py`
6 个测试用例，覆盖 issue #1189 的 3 个根因：

| 测试 | 覆盖场景 | 对应 issue 根因 |
|------|---------|---------------|
| `test_open_channel_succeeds_after_transient_ckb_rpc_failure` | 阻断 CKB RPC 3s 后恢复，channel 通过重试达到 ChannelReady | Issue 1 + 2 |
| `test_channel_aborted_after_retry_exhausted` | 持续阻断 35s，5 次重试耗尽后 channel 被 abort | 边界测试 |
| `test_open_channel_normal_via_proxy` | 代理透传模式，验证代理不干扰正常流程 | 对照测试 |
| `test_only_one_side_ckb_rpc_fails` | 仅 opener 侧 CKB RPC 失败，acceptor 正常 | Issue 1（非对称故障） |
| `test_sign_phase_retry_via_mid_flow_block` | cell 收集成功后在签名阶段触发故障 | Issue 3（SignFundingTx 重试） |
| `test_connection_reset_mid_flow` | TCP RST 模拟，复现 testnet.ckbapp.dev 的实际故障模式 | Issue 1（原始故障模式） |

## 验证结果

| 版本 | 通过 | 失败 |
|------|------|------|
| 修复版 (77019d93) | 6 passed | 0 |
| Buggy 版 (f1c656a1) | 2 passed | 4 failed |

4 个核心测试在 buggy 版本上正确失败，2 个边界/对照测试在两个版本上都通过。
