### PR TITLE
test: add open_channel_with_external_funding integration tests for PR#1120

### DIFF
--- a/test_cases/fiber/devnet/open_channel_with_external_funding/external_funding_base.py
+++ b/test_cases/fiber/devnet/open_channel_with_external_funding/external_funding_base.py
@@ -1,0 +1,434 @@
+import copy
+import json
+import os
+import re
+import tempfile
+import time
+
+from framework.basic_fiber import FiberTest
+from framework.config import DEFAULT_MIN_DEPOSIT_CKB
+
+
+class ExternalFundingBase(FiberTest):
+    __test__ = False
+
+    def _update_fiber_config_file(self, config_path, overrides):
+        with open(config_path) as f:
+            content = f.read()
+
+        for key, value in overrides.items():
+            rendered_line = f"  {key}: {value}"
+            pattern = rf"^  {re.escape(key)}:.*$"
+            if re.search(pattern, content, flags=re.MULTILINE):
+                content = re.sub(
+                    pattern, rendered_line, content, count=1, flags=re.MULTILINE
+                )
+                continue
+            content = content.replace("fiber:\n", f"fiber:\n{rendered_line}\n", 1)
+
+        with open(config_path, "w") as f:
+            f.write(content)
+
+    def _restart_fibers_with_config_overrides(
+        self, fiber1_overrides=None, fiber2_overrides=None
+    ):
+        fiber1_overrides = fiber1_overrides or {}
+        fiber2_overrides = fiber2_overrides or {}
+
+        self.fiber1.stop()
+        self.fiber2.stop()
+
+        if fiber1_overrides:
+            self._update_fiber_config_file(
+                self.fiber1.fiber_config_path, fiber1_overrides
+            )
+        if fiber2_overrides:
+            self._update_fiber_config_file(
+                self.fiber2.fiber_config_path, fiber2_overrides
+            )
+
+        self.fiber1.start(fnn_log_level=self.fnn_log_level)
+        self.fiber2.start(fnn_log_level=self.fnn_log_level)
+        self.fiber1.connect_peer(self.fiber2)
+        time.sleep(1)
+
+    def _sign_external_funding_tx(self, unsigned_funding_tx, external_private_key):
+        tx_file = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False
+            ) as tmp:
+                tx_file = tmp.name
+                json.dump(
+                    {
+                        "transaction": unsigned_funding_tx,
+                        "multisig_configs": {},
+                        "signatures": {},
+                    },
+                    tmp,
+                )
+
+            external_account = self.Ckb_cli.util_key_info_by_private_key(
+                external_private_key
+            )
+            self.Ckb_cli.tx_add_multisig_config(
+                external_account["address"]["testnet"],
+                tx_file,
+                self.node.rpcUrl,
+            )
+            sign_data = self.Ckb_cli.tx_sign_inputs(
+                external_private_key, tx_file, self.node.rpcUrl
+            )
+            for signature in sign_data:
+                self.Ckb_cli.tx_add_signature(
+                    signature["lock-arg"],
+                    signature["signature"],
+                    tx_file,
+                    self.node.rpcUrl,
+                )
+            return self.Tx.build_tx_info(tx_file)
+        finally:
+            if tx_file and os.path.exists(tx_file):
+                os.remove(tx_file)
+
+    def _clone_tx(self, tx):
+        return copy.deepcopy(tx)
+
+    def _build_external_open_params(
+        self,
+        external_private_key,
+        funding_amount,
+        public=True,
+        extra_params=None,
+    ):
+        params = {
+            "pubkey": self.fiber2.get_pubkey(),
+            "funding_amount": hex(funding_amount),
+            "public": public,
+            "shutdown_script": self.get_account_script(self.fiber1.account_private),
+            "funding_lock_script": self.get_account_script(external_private_key),
+        }
+        if extra_params:
+            params.update(extra_params)
+        return params
+
+    def _open_external_funding_channel(
+        self,
+        funding_amount=200 * 100000000,
+        public=True,
+        external_balance=1000,
+        extra_params=None,
+    ):
+        external_private_key = self.generate_account(external_balance)
+        open_result = self.fiber1.get_client().call(
+            "open_channel_with_external_funding",
+            [
+                self._build_external_open_params(
+                    external_private_key, funding_amount, public, extra_params
+                )
+            ],
+        )
+        return {
+            "funding_amount": funding_amount,
+            "external_private_key": external_private_key,
+            "external_lock_script": self.get_account_script(external_private_key),
+            "receiver_lock_script": self.get_account_script(
+                self.fiber2.account_private
+            ),
+            "channel_id": open_result["channel_id"],
+            "unsigned_funding_tx": open_result["unsigned_funding_tx"],
+            "open_result": open_result,
+        }
+
+    def _submit_external_funding(self, channel_id, signed_funding_tx):
+        return self.fiber1.get_client().call(
+            "submit_signed_funding_tx",
+            [
+                {
+                    "channel_id": channel_id,
+                    "signed_funding_tx": signed_funding_tx,
+                }
+            ],
+        )
+
+    def _open_sign_submit_external_channel(
+        self,
+        funding_amount=200 * 100000000,
+        public=True,
+        external_balance=1000,
+        extra_params=None,
+    ):
+        context = self._open_external_funding_channel(
+            funding_amount, public, external_balance, extra_params
+        )
+        signed_funding_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+        submit_result = self._submit_external_funding(
+            context["channel_id"], signed_funding_tx
+        )
+        context["signed_funding_tx"] = signed_funding_tx
+        context["submit_result"] = submit_result
+        context["funding_tx_hash"] = submit_result["funding_tx_hash"]
+        return context
+
+    def _get_channel_by_id(self, client, pubkey, channel_id, include_closed=False):
+        channels = client.list_channels(
+            {"pubkey": pubkey, "include_closed": include_closed}
+        )["channels"]
+        for channel in channels:
+            if channel["channel_id"] == channel_id:
+                return channel
+        raise AssertionError(f"channel not found: {channel_id}")
+
+    def _find_channel_by_id(self, client, pubkey, channel_id, include_closed=False):
+        channels = client.list_channels(
+            {"pubkey": pubkey, "include_closed": include_closed}
+        )["channels"]
+        for channel in channels:
+            if channel["channel_id"] == channel_id:
+                return channel
+        return None
+
+    def _wait_until_channel_absent(
+        self, client, pubkey, channel_id, timeout=20, include_closed=False
+    ):
+        for _ in range(timeout):
+            channel = self._find_channel_by_id(
+                client, pubkey, channel_id, include_closed=include_closed
+            )
+            if channel is None:
+                return
+            time.sleep(1)
+        raise AssertionError(f"channel still exists after timeout: {channel_id}")
+
+    def _wait_until_channel_condition(
+        self, client, pubkey, channel_id, predicate, timeout=20, include_closed=False
+    ):
+        last_channel = None
+        for _ in range(timeout):
+            channel = self._find_channel_by_id(
+                client, pubkey, channel_id, include_closed=include_closed
+            )
+            if channel is not None:
+                last_channel = channel
+                if predicate(channel):
+                    return channel
+            time.sleep(1)
+        raise AssertionError(
+            f"channel did not satisfy predicate in time: {channel_id}, last={last_channel}"
+        )
+
+    def _wait_until_state_not(
+        self, client, pubkey, channel_id, excluded_state, timeout=20
+    ):
+        return self._wait_until_channel_condition(
+            client,
+            pubkey,
+            channel_id,
+            lambda channel: channel["state"]["state_name"] != excluded_state,
+            timeout=timeout,
+        )
+
+    def _wait_both_channel_ready(self, channel_id, timeout=120):
+        self.wait_for_channel_state(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            "ChannelReady",
+            timeout,
+            channel_id=channel_id,
+        )
+        self.wait_for_channel_state(
+            self.fiber2.get_client(),
+            self.fiber1.get_pubkey(),
+            "ChannelReady",
+            timeout,
+            channel_id=channel_id,
+        )
+
+    def _wait_both_channel_closed(self, channel_id, timeout=120):
+        self.wait_for_channel_state(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            "Closed",
+            timeout,
+            include_closed=True,
+            channel_id=channel_id,
+        )
+        self.wait_for_channel_state(
+            self.fiber2.get_client(),
+            self.fiber1.get_pubkey(),
+            "Closed",
+            timeout,
+            include_closed=True,
+            channel_id=channel_id,
+        )
+
+    def _get_lock_capacity(self, lock_script):
+        return int(
+            self.node.getClient().get_cells_capacity(
+                {
+                    "script": lock_script,
+                    "script_type": "lock",
+                    "script_search_mode": "exact",
+                }
+            )["capacity"],
+            16,
+        )
+
+    def _get_script_capacity_delta_in_transaction(self, tx, lock_script):
+        input_total = 0
+        for tx_input in tx["inputs"]:
+            previous_output = tx_input["previous_output"]
+            previous_tx = self.node.getClient().get_transaction(
+                previous_output["tx_hash"]
+            )["transaction"]
+            previous_cell = previous_tx["outputs"][int(previous_output["index"], 16)]
+            if previous_cell["lock"] == lock_script:
+                input_total += int(previous_cell["capacity"], 16)
+
+        output_total = 0
+        for output in tx["outputs"]:
+            if output["lock"] == lock_script:
+                output_total += int(output["capacity"], 16)
+        return input_total - output_total
+
+    def _get_script_capacity_change_from_committed_tx(self, tx_hash, lock_script):
+        tx = self.node.getClient().get_transaction(tx_hash)["transaction"]
+        input_total = 0
+        for tx_input in tx["inputs"]:
+            previous_output = tx_input["previous_output"]
+            previous_tx = self.node.getClient().get_transaction(
+                previous_output["tx_hash"]
+            )["transaction"]
+            previous_cell = previous_tx["outputs"][int(previous_output["index"], 16)]
+            if previous_cell["lock"] == lock_script:
+                input_total += int(previous_cell["capacity"], 16)
+
+        output_total = 0
+        for output in tx["outputs"]:
+            if output["lock"] == lock_script:
+                output_total += int(output["capacity"], 16)
+        return output_total - input_total
+
+    def _format_capacity(self, value):
+        return f"{value / 100000000:.8f} CKB"
+
+    def _print_comparison(self, title, rows):
+        print(f"[{title}]")
+        for label, value in rows:
+            print(f"  {label}: {value}")
+
+    def _cap_row(self, label, value):
+        return (label, self._format_capacity(value))
+
+    def _formula_row(self, label, left, operator, right, result):
+        return (
+            label,
+            f"{self._format_capacity(left)} {operator} "
+            f"{self._format_capacity(right)} = {self._format_capacity(result)}",
+        )
+
+    def _print_payment_balance_summary(
+        self,
+        funding_amount,
+        sender_before,
+        sender_after,
+        receiver_before,
+        receiver_after,
+        invoice_amount,
+    ):
+        self._print_comparison(
+            "Payment channel balances",
+            [
+                self._cap_row("sender local_balance before payment", sender_before),
+                self._cap_row("sender local_balance after payment", sender_after),
+                self._formula_row(
+                    "sender formula",
+                    funding_amount,
+                    "-",
+                    DEFAULT_MIN_DEPOSIT_CKB,
+                    sender_before,
+                ),
+                self._cap_row(
+                    "sender paid through channel", sender_before - sender_after
+                ),
+                self._cap_row("receiver local_balance before payment", receiver_before),
+                self._cap_row("receiver local_balance after payment", receiver_after),
+                self._formula_row(
+                    "receiver formula",
+                    receiver_before,
+                    "+",
+                    invoice_amount,
+                    receiver_after,
+                ),
+                self._cap_row("invoice amount", invoice_amount),
+            ],
+        )
+
+    def _print_funding_settlement_summary(
+        self,
+        external_balance_before,
+        external_balance_after,
+        external_balance_delta,
+        expected_external_spend,
+    ):
+        self._print_comparison(
+            "Funding tx settlement",
+            [
+                self._cap_row(
+                    "external wallet chain before funding", external_balance_before
+                ),
+                self._cap_row(
+                    "external wallet chain after close", external_balance_after
+                ),
+                self._cap_row(
+                    "external wallet total chain delta", external_balance_delta
+                ),
+                self._cap_row("expected funding tx net spend", expected_external_spend),
+                self._formula_row(
+                    "external formula",
+                    external_balance_before,
+                    "-",
+                    external_balance_after,
+                    external_balance_delta,
+                ),
+            ],
+        )
+
+    def _print_close_settlement_summary(
+        self,
+        receiver_balance_after_open,
+        receiver_balance_after,
+        receiver_balance_delta,
+        expected_receiver_gain,
+        invoice_amount,
+    ):
+        self._print_comparison(
+            "Cooperative close settlement",
+            [
+                self._cap_row("receiver chain after open", receiver_balance_after_open),
+                self._cap_row("receiver chain after close", receiver_balance_after),
+                self._cap_row(
+                    "receiver post-close chain delta", receiver_balance_delta
+                ),
+                self._cap_row("expected close tx net gain", expected_receiver_gain),
+                self._formula_row(
+                    "receiver close formula",
+                    receiver_balance_after,
+                    "-",
+                    receiver_balance_after_open,
+                    receiver_balance_delta,
+                ),
+                (
+                    "receiver theoretical gross",
+                    f"{self._format_capacity(DEFAULT_MIN_DEPOSIT_CKB)} + "
+                    f"{self._format_capacity(invoice_amount)}",
+                ),
+            ],
+        )
+
+    def _restart_fiber(self, fiber):
+        fiber.stop()
+        fiber.start(fnn_log_level=self.fnn_log_level)
+        time.sleep(1)

--- a/test_cases/fiber/devnet/open_channel_with_external_funding/test_basic_flow.py
+++ b/test_cases/fiber/devnet/open_channel_with_external_funding/test_basic_flow.py
@@ -1,0 +1,122 @@
+from test_cases.fiber.devnet.open_channel_with_external_funding.external_funding_base import (
+    ExternalFundingBase,
+)
+
+
+class TestExternalFundingBasicFlow(ExternalFundingBase):
+    """
+    PR-1120 basic integration coverage.
+
+    Mapped doc cases:
+    - T-01 open external funding channel and inspect unsigned tx
+    - T-02 submit signed funding tx and observe state progression
+    - T-18 public channel support
+    - T-19 custom funding_lock_script_cell_deps propagation
+    - T-21 pre-submit list_channels observation
+
+    Note:
+    - T-04 is intentionally consolidated into test_main_flow.py to avoid
+      running a second full ready-handshake verification path.
+    """
+
+    __test__ = True
+
+    def test_open_channel_returns_unsigned_funding_tx(self):
+        """
+        T-01: verify open_channel_with_external_funding returns channel_id and
+        an unsigned funding transaction with placeholder witnesses.
+        """
+        context = self._open_external_funding_channel(public=True)
+        unsigned_funding_tx = context["unsigned_funding_tx"]
+
+        assert context["channel_id"].startswith("0x")
+        assert len(context["channel_id"]) == 66
+        assert len(unsigned_funding_tx["outputs"]) > 0
+        # External funding unsigned tx uses zero-filled placeholder witnesses rather than
+        # real signatures. The dynamic witness payload should therefore remain all zeros.
+        assert all(
+            witness.startswith("0x") and int(witness[42:], 16) == 0
+            for witness in unsigned_funding_tx["witnesses"]
+        )
+
+    def test_submit_signed_funding_tx_progresses_channel_state(self):
+        """
+        T-02: verify submit_signed_funding_tx accepts a properly signed tx and
+        moves the initiator out of AwaitingExternalFunding.
+        """
+        context = self._open_external_funding_channel(public=True)
+        signed_funding_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+
+        submit_result = self._submit_external_funding(
+            context["channel_id"], signed_funding_tx
+        )
+
+        assert submit_result["channel_id"] == context["channel_id"]
+        assert submit_result["funding_tx_hash"].startswith("0x")
+
+        progressed_channel = self._wait_until_state_not(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            context["channel_id"],
+            "AwaitingExternalFunding",
+            timeout=20,
+        )
+        assert progressed_channel["state"]["state_name"] != "AwaitingExternalFunding"
+
+    def test_external_funding_public_channel(self):
+        """T-18: verify external funding channels can be opened as public."""
+        context = self._open_sign_submit_external_channel(public=True)
+
+        self.Miner.miner_until_tx_committed(self.node, context["funding_tx_hash"], True)
+        self._wait_both_channel_ready(context["channel_id"])
+
+        initiator_channel = self._get_channel_by_id(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), context["channel_id"]
+        )
+        acceptor_channel = self._get_channel_by_id(
+            self.fiber2.get_client(), self.fiber1.get_pubkey(), context["channel_id"]
+        )
+        assert initiator_channel["is_public"] is True
+        assert acceptor_channel["is_public"] is True
+
+    def test_unsigned_funding_tx_contains_custom_cell_deps(self):
+        """
+        T-19: verify user-supplied funding_lock_script_cell_deps are copied into
+        unsigned_funding_tx.cell_deps.
+        """
+        deploy_hash, deploy_index = self.udtContract.get_deploy_hash_and_index()
+        custom_dep = {
+            "out_point": {
+                "tx_hash": deploy_hash,
+                "index": hex(deploy_index),
+            },
+            "dep_type": "code",
+        }
+        context = self._open_external_funding_channel(
+            public=True,
+            extra_params={"funding_lock_script_cell_deps": [custom_dep]},
+        )
+
+        assert custom_dep in context["unsigned_funding_tx"]["cell_deps"]
+
+    def test_list_channels_before_submit_shows_absent_or_awaiting_external_funding(
+        self,
+    ):
+        """
+        T-21: before submit, the channel may be absent from list_channels or it
+        may already appear in AwaitingExternalFunding. Both are valid.
+        """
+        context = self._open_external_funding_channel(public=True)
+        initiator_channel = self._find_channel_by_id(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), context["channel_id"]
+        )
+        acceptor_channel = self._find_channel_by_id(
+            self.fiber2.get_client(), self.fiber1.get_pubkey(), context["channel_id"]
+        )
+
+        for channel in (initiator_channel, acceptor_channel):
+            if channel is None:
+                continue
+            assert channel["state"]["state_name"] == "AwaitingExternalFunding"

--- a/test_cases/fiber/devnet/open_channel_with_external_funding/test_compatibility.py
+++ b/test_cases/fiber/devnet/open_channel_with_external_funding/test_compatibility.py
@@ -1,0 +1,71 @@
+from test_cases.fiber.devnet.open_channel_with_external_funding.external_funding_base import (
+    ExternalFundingBase,
+)
+
+
+class TestExternalFundingCompatibility(ExternalFundingBase):
+    """
+    PR-1120 backward compatibility coverage.
+
+    Mapped doc case:
+    - T-20 normal open_channel flow should remain unchanged
+    """
+
+    __test__ = True
+
+    def test_normal_open_channel_flow_still_works(self):
+        """
+        T-20: verify the new external funding RPCs do not regress the existing
+        normal open_channel -> pay -> close workflow.
+        """
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 0)
+        channel_id = self.fiber1.get_client().list_channels(
+            {"pubkey": self.fiber2.get_pubkey()}
+        )["channels"][0]["channel_id"]
+
+        invoice_amount = 10 * 100000000
+        invoice = self.fiber2.get_client().new_invoice(
+            {
+                "amount": hex(invoice_amount),
+                "currency": "Fibd",
+                "description": "normal open_channel compatibility payment",
+                "expiry": "0xe10",
+                "final_cltv": "0x28",
+                "payment_preimage": self.generate_random_preimage(),
+                "hash_algorithm": "sha256",
+            }
+        )
+        before_channel = self._get_channel_by_id(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), channel_id
+        )
+        payment = self.fiber1.get_client().send_payment(
+            {"invoice": invoice["invoice_address"]}
+        )
+        self.wait_payment_state(self.fiber1, payment["payment_hash"], "Success")
+        after_channel = self._get_channel_by_id(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), channel_id
+        )
+        assert (
+            int(before_channel["local_balance"], 16)
+            - int(after_channel["local_balance"], 16)
+            == invoice_amount
+        )
+
+        self.fiber1.get_client().shutdown_channel(
+            {
+                "channel_id": channel_id,
+                "close_script": self.get_account_script(self.fiber1.account_private),
+                "fee_rate": "0x3FC",
+            }
+        )
+        close_tx_hash = self.wait_and_check_tx_pool_fee(1000, False, 120)
+        self.Miner.miner_until_tx_committed(self.node, close_tx_hash, True)
+        self._wait_both_channel_closed(channel_id)
+
+        closed_channel = self._get_channel_by_id(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            channel_id,
+            include_closed=True,
+        )
+        assert closed_channel["state"]["state_name"] == "Closed"

--- a/test_cases/fiber/devnet/open_channel_with_external_funding/test_invalid_signed_tx.py
+++ b/test_cases/fiber/devnet/open_channel_with_external_funding/test_invalid_signed_tx.py
@@ -1,0 +1,223 @@
+import re
+
+import pytest
+
+from test_cases.fiber.devnet.open_channel_with_external_funding.external_funding_base import (
+    ExternalFundingBase,
+)
+
+
+class TestExternalFundingInvalidSignedTx(ExternalFundingBase):
+    """
+    PR-1120 invalid signed transaction and state-check coverage.
+
+    Mapped doc cases:
+    - T-05/T-06/T-07/T-08/T-22/T-23 tampered funding transaction validation
+    - T-09/T-10/T-11 invalid submit_signed_funding_tx state checks
+    """
+
+    __test__ = True
+
+    @staticmethod
+    def _assert_raw_data_mismatch(error_message, *legacy_markers):
+        if "Signed funding transaction raw data mismatch" in error_message:
+            return
+        for marker in legacy_markers:
+            if marker in error_message:
+                return
+        raise AssertionError(
+            "Expected a raw-data mismatch style error, "
+            f"got '{error_message}' instead"
+        )
+
+    def _submit_tampered_tx_and_get_error(self, tamper_fn):
+        """Shared helper for T-05 to T-07 style invalid signed transaction tests."""
+        context = self._open_external_funding_channel(public=True)
+        tampered_tx = self._clone_tx(context["unsigned_funding_tx"])
+        tamper_fn(tampered_tx)
+        signed_tampered_tx = self._sign_external_funding_tx(
+            tampered_tx, context["external_private_key"]
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(context["channel_id"], signed_tampered_tx)
+        return exc_info.value.args[0]
+
+    def test_output_mismatch(self):
+        """T-05: outputs modified from unsigned_funding_tx should be rejected."""
+
+        def tamper(tx):
+            tx["outputs"][0]["capacity"] = hex(
+                int(tx["outputs"][0]["capacity"], 16) + 1
+            )
+
+        error_message = self._submit_tampered_tx_and_get_error(tamper)
+        self._assert_raw_data_mismatch(error_message, "Output 0 mismatch")
+
+    def test_input_count_mismatch(self):
+        """T-06: input count mismatch against the original unsigned tx should fail."""
+
+        def tamper(tx):
+            tx["inputs"].append(self._clone_tx(tx["inputs"][0]))
+
+        error_message = self._submit_tampered_tx_and_get_error(tamper)
+        if "Signed funding transaction raw data mismatch" not in error_message:
+            error_pattern = r"Input count mismatch: unsigned has \d+, signed has \d+"
+            assert re.search(error_pattern, error_message), (
+                f"Expected pattern '{error_pattern}' "
+                f"not found in actual string '{error_message}'"
+            )
+
+    def test_output_data_mismatch(self):
+        """T-07: outputs_data tampering should be rejected as a mismatch."""
+
+        def tamper(tx):
+            tx["outputs_data"][0] = (
+                "0x01" if tx["outputs_data"][0] in ("0x", "0x0") else "0x"
+            )
+
+        error_message = self._submit_tampered_tx_and_get_error(tamper)
+        self._assert_raw_data_mismatch(error_message, "Output data 0 mismatch")
+
+    def test_previous_output_mismatch(self):
+        """
+        T-08: previous_output must remain identical to the unsigned template.
+
+        We sign the original unsigned tx first, then tamper the signed copy, so
+        the submit path validates the mismatch instead of failing earlier in the
+        local signing helper.
+        """
+        context = self._open_external_funding_channel(public=True)
+        signed_funding_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+        tampered_signed_tx = self._clone_tx(signed_funding_tx)
+        current_index = int(
+            tampered_signed_tx["inputs"][0]["previous_output"]["index"], 16
+        )
+        tampered_signed_tx["inputs"][0]["previous_output"]["index"] = hex(
+            current_index + 1
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(context["channel_id"], tampered_signed_tx)
+
+        error_message = exc_info.value.args[0]
+        self._assert_raw_data_mismatch(
+            error_message, "Input 0 previous_output mismatch"
+        )
+
+    def test_output_count_mismatch(self):
+        """
+        T-22: outputs count must remain identical to the unsigned template.
+
+        We tamper the already signed transaction copy so the submit path hits the
+        output-count validation directly.
+        """
+        context = self._open_external_funding_channel(public=True)
+        signed_funding_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+        tampered_signed_tx = self._clone_tx(signed_funding_tx)
+        tampered_signed_tx["outputs"].pop()
+        tampered_signed_tx["outputs_data"].pop()
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(context["channel_id"], tampered_signed_tx)
+
+        error_message = exc_info.value.args[0]
+        if "Signed funding transaction raw data mismatch" not in error_message:
+            error_pattern = r"Output count mismatch: unsigned has \d+, signed has \d+"
+            assert re.search(error_pattern, error_message), (
+                f"Expected pattern '{error_pattern}' "
+                f"not found in actual string '{error_message}'"
+            )
+
+    def test_outputs_data_count_mismatch(self):
+        """
+        T-23: outputs_data count must stay aligned with outputs.
+
+        This specifically targets array-length mismatch rather than content
+        mismatch, so we only change outputs_data length.
+        """
+        context = self._open_external_funding_channel(public=True)
+        signed_funding_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+        tampered_signed_tx = self._clone_tx(signed_funding_tx)
+        tampered_signed_tx["outputs_data"].pop()
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(context["channel_id"], tampered_signed_tx)
+
+        error_message = exc_info.value.args[0]
+        if "Signed funding transaction raw data mismatch" not in error_message:
+            error_pattern = (
+                r"Outputs data count mismatch: unsigned has \d+, signed has \d+"
+            )
+            assert re.search(error_pattern, error_message), (
+                f"Expected pattern '{error_pattern}' "
+                f"not found in actual string '{error_message}'"
+            )
+
+    def test_submit_signed_funding_tx_on_normal_channel(self):
+        """
+        T-09: submit_signed_funding_tx only applies to channels waiting for
+        external funding, not to ordinary open_channel flows.
+        """
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 0)
+        normal_channel_id = self.fiber1.get_client().list_channels(
+            {"pubkey": self.fiber2.get_pubkey()}
+        )["channels"][0]["channel_id"]
+        external_context = self._open_external_funding_channel(public=True)
+        signed_funding_tx = self._sign_external_funding_tx(
+            external_context["unsigned_funding_tx"],
+            external_context["external_private_key"],
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(normal_channel_id, signed_funding_tx)
+
+        error_message = exc_info.value.args[0]
+        error_pattern = (
+            r"Expected channel in "
+            r"(?:AwaitingExternalFunding|AWAITING_EXTERNAL_FUNDING)-compatible state, "
+            r"but got [A-Za-z_]+"
+        )
+        assert re.search(error_pattern, error_message), (
+            f"Expected pattern '{error_pattern}' "
+            f"not found in actual string '{error_message}'"
+        )
+
+    def test_duplicate_submit_signed_funding_tx(self):
+        """T-10: the same signed funding tx cannot be submitted twice."""
+        context = self._open_sign_submit_external_channel(public=True)
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(
+                context["channel_id"], context["signed_funding_tx"]
+            )
+
+        expected_error_message = "Signed funding tx has already been submitted"
+        assert expected_error_message in exc_info.value.args[0], (
+            f"Expected substring '{expected_error_message}' "
+            f"not found in actual string '{exc_info.value.args[0]}'"
+        )
+
+    def test_submit_signed_funding_tx_with_nonexistent_channel_id(self):
+        """T-11: submitting against an unknown channel_id should return an error."""
+        context = self._open_external_funding_channel(public=True)
+        signed_funding_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+        fake_channel_id = self.generate_random_preimage()
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(fake_channel_id, signed_funding_tx)
+
+        error_message = exc_info.value.args[0]
+        error_pattern = r"Channel not found error: Hash256\(0x[0-9a-f]{64}\)"
+        assert re.search(error_pattern, error_message), (
+            f"Expected pattern '{error_pattern}' "
+            f"not found in actual string '{error_message}'"
+        )

--- a/test_cases/fiber/devnet/open_channel_with_external_funding/test_main_flow.py
+++ b/test_cases/fiber/devnet/open_channel_with_external_funding/test_main_flow.py
@@ -1,0 +1,179 @@
+from test_cases.fiber.devnet.open_channel_with_external_funding.external_funding_base import (
+    ExternalFundingBase,
+)
+
+
+class TestOpenChannelWithExternalFunding(ExternalFundingBase):
+    """
+    PR-1120 main integration flow.
+
+    Mapped doc cases:
+    - T-03 full lifecycle: open -> sign/submit -> ready -> pay -> close
+    - T-04 both peers reach ChannelReady after funding confirmation
+    """
+
+    __test__ = True
+
+    def test_main_flow(self):
+        """
+        T-03/T-04 combined happy path.
+
+        This is the end-to-end regression case that proves an externally funded
+        channel can be opened, used for payment, and cooperatively closed while
+        both peers observe the expected state transitions.
+        """
+        # Step 0: prepare an external wallet that funds the channel on-chain.
+        # Validation target: the funding source is not fiber1's own CKB key.
+        context = self._open_external_funding_channel(public=True)
+        channel_id = context["channel_id"]
+        funding_amount = context["funding_amount"]
+        external_lock_script = context["external_lock_script"]
+        receiver_lock_script = context["receiver_lock_script"]
+        external_balance_before = self._get_lock_capacity(external_lock_script)
+        receiver_balance_before = self._get_lock_capacity(receiver_lock_script)
+        node_info = self.fiber1.get_client().node_info()
+        print(
+            f"fiber1 version: {node_info['version']}, commit_hash: {node_info['commit_hash']}"
+        )
+
+        context["signed_funding_tx"] = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+        context["submit_result"] = self._submit_external_funding(
+            context["channel_id"], context["signed_funding_tx"]
+        )
+        context["funding_tx_hash"] = context["submit_result"]["funding_tx_hash"]
+        expected_external_spend = self._get_script_capacity_delta_in_transaction(
+            context["signed_funding_tx"], external_lock_script
+        )
+
+        assert context["submit_result"]["channel_id"] == channel_id
+        assert context["funding_tx_hash"].startswith("0x")
+        assert expected_external_spend >= funding_amount
+
+        self.Miner.miner_until_tx_committed(self.node, context["funding_tx_hash"], True)
+
+        # T-04: after the signed funding tx is accepted and confirmed, both peers
+        # should complete the commitment handshake and reach ChannelReady.
+        self._wait_both_channel_ready(channel_id)
+        receiver_channel_before_payment = self._get_channel_by_id(
+            self.fiber2.get_client(), self.fiber1.get_pubkey(), channel_id
+        )
+        assert int(receiver_channel_before_payment["local_balance"], 16) == 0
+        receiver_balance_after_open = self._get_lock_capacity(receiver_lock_script)
+        assert receiver_balance_after_open < receiver_balance_before
+
+        # T-03 (payment part): pay through the externally funded channel.
+        # Validation target:
+        # - invoice payment reaches Success
+        # - fiber1 local_balance decreases exactly by the invoice amount
+        invoice_amount = 10 * 100000000
+        invoice = self.fiber2.get_client().new_invoice(
+            {
+                "amount": hex(invoice_amount),
+                "currency": "Fibd",
+                "description": "external funding channel payment",
+                "expiry": "0xe10",
+                "final_cltv": "0x28",
+                "payment_preimage": self.generate_random_preimage(),
+                "hash_algorithm": "sha256",
+            }
+        )
+        before_channel = self._get_channel_by_id(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), channel_id
+        )
+        payment = self.fiber1.get_client().send_payment(
+            {
+                "invoice": invoice["invoice_address"],
+            }
+        )
+        self.wait_payment_state(self.fiber1, payment["payment_hash"], "Success")
+        after_channel = self._get_channel_by_id(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), channel_id
+        )
+        receiver_channel_after_payment = self._get_channel_by_id(
+            self.fiber2.get_client(), self.fiber1.get_pubkey(), channel_id
+        )
+        sender_channel_before_payment = int(before_channel["local_balance"], 16)
+        sender_channel_after_payment = int(after_channel["local_balance"], 16)
+        receiver_channel_before_payment_balance = int(
+            receiver_channel_before_payment["local_balance"], 16
+        )
+        receiver_channel_after_payment_balance = int(
+            receiver_channel_after_payment["local_balance"], 16
+        )
+        # Payment formulas for this PR-1120 main flow:
+        # - sender local_balance before payment = funding_amount - DEFAULT_MIN_DEPOSIT_CKB
+        #   e.g. 200 CKB - 99 CKB = 101 CKB
+        # - sender local_balance delta = invoice_amount
+        # - receiver local_balance after payment = 0 + invoice_amount
+        self._print_payment_balance_summary(
+            funding_amount,
+            sender_channel_before_payment,
+            sender_channel_after_payment,
+            receiver_channel_before_payment_balance,
+            receiver_channel_after_payment_balance,
+            invoice_amount,
+        )
+        assert sender_channel_before_payment - sender_channel_after_payment == (
+            invoice_amount
+        )
+        assert receiver_channel_after_payment_balance == invoice_amount
+
+        # T-03 (close part): cooperatively close the channel and confirm the close tx.
+        # Validation target:
+        # - close tx enters the pool and gets committed
+        # - both sides can observe the channel in Closed state with include_closed=True
+        self.fiber1.get_client().shutdown_channel(
+            {
+                "channel_id": channel_id,
+                "close_script": self.get_account_script(self.fiber1.account_private),
+                "fee_rate": "0x3FC",
+            }
+        )
+        close_tx_hash = self.wait_and_check_tx_pool_fee(1000, False, 120)
+        self.Miner.miner_until_tx_committed(self.node, close_tx_hash, True)
+        self._wait_both_channel_closed(channel_id)
+
+        closed_channel = self._get_channel_by_id(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            channel_id,
+            include_closed=True,
+        )
+        assert closed_channel["state"]["state_name"] == "Closed"
+
+        # Final chain balance checks:
+        # - the external wallet's total chain loss should equal the exact fee-adjusted
+        #   net spend in the funding tx
+        # - the receiver's post-close chain gain should equal the exact fee-adjusted
+        #   amount delivered to its lock script by the committed cooperative close tx
+        external_balance_after = self._get_lock_capacity(external_lock_script)
+        receiver_balance_after = self._get_lock_capacity(receiver_lock_script)
+        expected_receiver_gain = self._get_script_capacity_change_from_committed_tx(
+            close_tx_hash, receiver_lock_script
+        )
+        external_balance_delta = external_balance_before - external_balance_after
+        receiver_balance_delta = receiver_balance_after - receiver_balance_after_open
+
+        # Final settlement formulas:
+        # - external wallet total chain delta = chain before funding - chain after close
+        #   = funding_amount + opening fee
+        # - receiver post-close chain delta = chain after close - chain after open
+        #   = DEFAULT_MIN_DEPOSIT_CKB + invoice_amount - close fee share
+        self._print_funding_settlement_summary(
+            external_balance_before,
+            external_balance_after,
+            external_balance_delta,
+            expected_external_spend,
+        )
+        self._print_close_settlement_summary(
+            receiver_balance_after_open,
+            receiver_balance_after,
+            receiver_balance_delta,
+            expected_receiver_gain,
+            invoice_amount,
+        )
+
+        assert external_balance_delta == expected_external_spend
+        assert receiver_balance_delta == expected_receiver_gain

--- a/test_cases/fiber/devnet/open_channel_with_external_funding/test_params_and_timeout.py
+++ b/test_cases/fiber/devnet/open_channel_with_external_funding/test_params_and_timeout.py
@@ -1,0 +1,166 @@
+import re
+import time
+
+import pytest
+
+from test_cases.fiber.devnet.open_channel_with_external_funding.external_funding_base import (
+    ExternalFundingBase,
+)
+
+
+class TestExternalFundingParams(ExternalFundingBase):
+    """
+    PR-1120 parameter validation coverage.
+
+    Mapped doc cases:
+    - T-12 tlc_expiry_delta lower-bound validation
+    - T-13 commitment_delay_epoch lower-bound validation
+    - T-24 funding_amount lower-bound validation
+    """
+
+    __test__ = True
+
+    def test_tlc_expiry_delta_too_small(self):
+        """T-12: tlc_expiry_delta below the minimum should be rejected by RPC."""
+        with pytest.raises(Exception) as exc_info:
+            self._open_external_funding_channel(
+                public=True, extra_params={"tlc_expiry_delta": "0x1"}
+            )
+
+        error_message = exc_info.value.args[0]
+        error_pattern = r"TLC expiry delta is too small, expect larger than \d+, got 1"
+        assert re.search(error_pattern, error_message), (
+            f"Expected pattern '{error_pattern}' "
+            f"not found in actual string '{error_message}'"
+        )
+
+    def test_commitment_delay_epoch_too_small(self):
+        """T-13: commitment_delay_epoch of zero should be rejected by RPC."""
+        with pytest.raises(Exception) as exc_info:
+            self._open_external_funding_channel(
+                public=True, extra_params={"commitment_delay_epoch": "0x0"}
+            )
+
+        error_message = exc_info.value.args[0]
+        error_pattern = r"Commitment delay epoch .+ is less than the minimal value .+"
+        assert re.search(error_pattern, error_message), (
+            f"Expected pattern '{error_pattern}' "
+            f"not found in actual string '{error_message}'"
+        )
+
+    def test_funding_amount_too_small(self):
+        """T-24: funding_amount of zero should be rejected by RPC."""
+        with pytest.raises(Exception) as exc_info:
+            self._open_external_funding_channel(funding_amount=0, public=True)
+
+        error_message = exc_info.value.args[0]
+        error_pattern = (
+            r"The funding amount \(0\) should be greater than or equal to \d+"
+        )
+        assert re.search(error_pattern, error_message), (
+            f"Expected pattern '{error_pattern}' "
+            f"not found in actual string '{error_message}'"
+        )
+
+
+class TestExternalFundingTimeoutLifecycle(ExternalFundingBase):
+    """
+    PR-1120 timeout and lifecycle coverage.
+
+    Mapped doc cases:
+    - T-14 timeout cleanup before signature submission
+    - T-15 stale timeout must not abort a submitted channel
+    - T-16 abandon while AwaitingExternalFunding
+    - T-17 restart drops non-persisted AwaitingExternalFunding channel
+    """
+
+    __test__ = True
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self._restart_fibers_with_config_overrides(
+            fiber1_overrides={
+                "external_funding_timeout_seconds": 1,
+                "funding_timeout_seconds": 10,
+            }
+        )
+
+    def test_external_funding_timeout_aborts_pending_channel(self):
+        """
+        T-14: if no signed funding tx is submitted before timeout, the pending
+        channel should disappear and later submit attempts should fail.
+        """
+        context = self._open_external_funding_channel(public=True)
+        signed_funding_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+
+        time.sleep(2)
+        self._wait_until_channel_absent(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), context["channel_id"], 5
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(context["channel_id"], signed_funding_tx)
+
+        error_message = exc_info.value.args[0]
+        error_pattern = r"Channel not found error: Hash256\(0x[0-9a-f]{64}\)"
+        assert re.search(error_pattern, error_message), (
+            f"Expected pattern '{error_pattern}' "
+            f"not found in actual string '{error_message}'"
+        )
+
+    def test_signed_submission_is_not_aborted_by_stale_timeout(self):
+        """
+        T-15: after a timely submit_signed_funding_tx call, a previously
+        scheduled timeout event must not tear down the channel.
+        """
+        context = self._open_sign_submit_external_channel(public=True)
+
+        time.sleep(2)
+        channel = self._find_channel_by_id(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), context["channel_id"]
+        )
+        assert channel is not None
+        assert channel["state"]["state_name"] != "Closed"
+
+        self.Miner.miner_until_tx_committed(self.node, context["funding_tx_hash"], True)
+        self._wait_both_channel_ready(context["channel_id"], 120)
+
+    def test_abandon_channel_while_awaiting_external_funding(self):
+        """T-16: abandon_channel should actively cancel AwaitingExternalFunding."""
+        context = self._open_external_funding_channel(public=True)
+
+        response = self.fiber1.get_client().abandon_channel(
+            {"channel_id": context["channel_id"]}
+        )
+        assert response is None or response == {}
+        self._wait_until_channel_absent(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), context["channel_id"], 5
+        )
+
+    def test_restart_drops_awaiting_external_funding_channel(self):
+        """
+        T-17: AwaitingExternalFunding is intentionally non-persistent, so the
+        channel should be lost after a node restart.
+        """
+        context = self._open_external_funding_channel(public=True)
+        signed_funding_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+
+        self._restart_fiber(self.fiber1)
+        self.fiber1.connect_peer(self.fiber2)
+        self._wait_until_channel_absent(
+            self.fiber1.get_client(), self.fiber2.get_pubkey(), context["channel_id"], 5
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            self._submit_external_funding(context["channel_id"], signed_funding_tx)
+
+        error_message = exc_info.value.args[0]
+        error_pattern = r"Channel not found error: Hash256\(0x[0-9a-f]{64}\)"
+        assert re.search(error_pattern, error_message), (
+            f"Expected pattern '{error_pattern}' "
+            f"not found in actual string '{error_message}'"
+        )

--- a/test_cases/fiber/devnet/open_channel_with_external_funding/test_preconditions.py
+++ b/test_cases/fiber/devnet/open_channel_with_external_funding/test_preconditions.py
@@ -1,0 +1,43 @@
+import re
+import time
+
+import pytest
+
+from test_cases.fiber.devnet.open_channel_with_external_funding.external_funding_base import (
+    ExternalFundingBase,
+)
+
+
+class TestExternalFundingPreconditions(ExternalFundingBase):
+    """
+    PR-1120 precondition coverage.
+
+    Mapped doc case:
+    - T-25 open_channel_with_external_funding requires an active peer connection
+    """
+
+    __test__ = True
+
+    def test_open_channel_with_external_funding_requires_connected_peer(self):
+        """
+        T-25: when the target peer is disconnected, the RPC should fail with a
+        peer/connect related error instead of creating a pending channel.
+        """
+        self.fiber1.get_client().disconnect_peer({"pubkey": self.fiber2.get_pubkey()})
+
+        for _ in range(10):
+            if len(self.fiber1.get_client().list_peers()["peers"]) == 0:
+                break
+            time.sleep(1)
+        else:
+            raise AssertionError("fiber1 still shows connected peers after disconnect")
+
+        with pytest.raises(Exception) as exc_info:
+            self._open_external_funding_channel(public=True)
+
+        error_message = exc_info.value.args[0]
+        error_pattern = r"Peer Pubkey\([^)]+\) is not connected"
+        assert re.search(error_pattern, error_message), (
+            f"Expected pattern '{error_pattern}' "
+            f"not found in actual string '{error_message}'"
+        )


### PR DESCRIPTION
## Summary

为 Fiber PR [nervosnetwork/fiber#1120](https://github.com/nervosnetwork/fiber/pull/1120) 编写集成测试，验证通过外部钱包签名 funding 交易来开通通道的完整功能。

该 PR 新增两个 RPC —— `open_channel_with_external_funding` 和 `submit_signed_funding_tx`，允许用户使用外部钱包签名 funding 交易来开通通道，不再要求 FNN 节点持有 CKB 私钥。

## 新增文件

### `test_cases/fiber/devnet/open_channel_with_external_funding/external_funding_base.py`

测试基类，封装外部资金通道的公共逻辑：

- `_sign_external_funding_tx()` — 使用 ckb-cli 对 unsigned funding tx 签名
- `_open_external_funding_channel()` — 调用 `open_channel_with_external_funding` RPC
- `_submit_external_funding()` — 调用 `submit_signed_funding_tx` RPC
- `_open_sign_submit_external_channel()` — 一站式完成开通+签名+提交
- 链上余额对账辅助方法

### `test_cases/fiber/devnet/open_channel_with_external_funding/test_basic_flow.py`

5 个测试用例，覆盖基础流程和功能验证：

| 测试方法 | 覆盖场景 | 对应测试用例 |
|---------|---------|------------|
| test_open_channel_returns_unsigned_funding_tx | 验证 RPC 返回 channel_id 和未签名交易 | T-01 |
| test_submit_signed_funding_tx_progresses_channel_state | 验证签名交易提交后通道状态推进 | T-02 |
| test_external_funding_public_channel | 验证外部资金通道可设为公共通道 | T-18 |
| test_unsigned_funding_tx_contains_custom_cell_deps | 验证自定义 cell deps 被正确传递 | T-19 |
| test_list_channels_before_submit_shows_absent_or_awaiting | 验证提交前通道状态观察 | T-21 |

### `test_cases/fiber/devnet/open_channel_with_external_funding/test_main_flow.py`

1 个端到端测试，验证完整生命周期：

| 测试方法 | 覆盖场景 | 对应测试用例 |
|---------|---------|------------|
| test_main_flow | 开通→签名→提交→就绪→支付→关闭+链上余额对账 | T-03, T-04 |

### `test_cases/fiber/devnet/open_channel_with_external_funding/test_invalid_signed_tx.py`

9 个测试用例，覆盖交易验证和状态检查：

| 测试方法 | 覆盖场景 | 对应测试用例 |
|---------|---------|------------|
| test_output_mismatch | output 被篡改的交易被拒绝 | T-05 |
| test_input_count_mismatch | input 数量不一致被拒绝 | T-06 |
| test_output_data_mismatch | output_data 被篡改被拒绝 | T-07 |
| test_previous_output_mismatch | previous_output 被篡改被拒绝 | T-08 |
| test_output_count_mismatch | output 数量不一致被拒绝 | T-22 |
| test_outputs_data_count_mismatch | outputs_data 数量不一致被拒绝 | T-23 |
| test_submit_signed_funding_tx_on_normal_channel | 对普通通道调用被拒绝 | T-09 |
| test_duplicate_submit_signed_funding_tx | 重复提交被拒绝 | T-10 |
| test_submit_signed_funding_tx_with_nonexistent_channel_id | 不存在的 channel_id 被拒绝 | T-11 |

### `test_cases/fiber/devnet/open_channel_with_external_funding/test_params_and_timeout.py`

7 个测试用例，覆盖参数验证和超时生命周期：

| 测试方法 | 覆盖场景 | 对应测试用例 |
|---------|---------|------------|
| test_tlc_expiry_delta_too_small | tlc_expiry_delta 下限校验 | T-12 |
| test_commitment_delay_epoch_too_small | commitment_delay_epoch 下限校验 | T-13 |
| test_funding_amount_too_small | funding_amount 下限校验 | T-24 |
| test_external_funding_timeout_aborts_pending_channel | 超时自动中止 | T-14 |
| test_signed_submission_is_not_aborted_by_stale_timeout | 已提交后超时不影响通道 | T-15 |
| test_abandon_channel_while_awaiting_external_funding | 主动中止等待中的通道 | T-16 |
| test_restart_drops_awaiting_external_funding_channel | 重启后通道丢失 | T-17 |

### `test_cases/fiber/devnet/open_channel_with_external_funding/test_compatibility.py`

1 个测试用例，验证向后兼容性：

| 测试方法 | 覆盖场景 | 对应测试用例 |
|---------|---------|------------|
| test_normal_open_channel_flow_still_works | 普通 open_channel 流程不受影响 | T-20 |

### `test_cases/fiber/devnet/open_channel_with_external_funding/test_preconditions.py`

1 个测试用例，验证前置条件：

| 测试方法 | 覆盖场景 | 对应测试用例 |
|---------|---------|------------|
| test_open_channel_with_external_funding_requires_connected_peer | 未连接 peer 时调用被拒绝 | T-25 |

## 测试用例覆盖汇总

共 24 个测试方法，覆盖 [测试分析文档](https://github.com/sunchengzhu/fiber/blob/copilot/test-analysis-for-pr-1120/docs/pr-1120-test-analysis.md) 中全部 25 个测试用例（T-03/T-04 合并为一个端到端测试）。
