### PR TITLE
chore: 将 Fiber 默认版本从 v0.8.0 升级到 v0.8.1

### DIFF
--- a/download_fiber.py
+++ b/download_fiber.py
@@ -17,6 +17,7 @@ versions = [
     "0.7.0",
     "0.7.1",
     "0.8.0",
+    "0.8.1",
 ]
 
 DOWNLOAD_DIR = "download/fiber"

--- a/framework/test_fiber.py
+++ b/framework/test_fiber.py
@@ -58,12 +58,12 @@ class FiberConfigPath(Enum):
 
     CURRENT_MAINNET = (
         "/source/template/fiber/mainnet_config_3.yml.j2",
-        "download/fiber/0.8.0/fnn",
+        "download/fiber/0.8.1/fnn",
     )
 
     CURRENT_TESTNET = (
         "/source/template/fiber/testnet_config_3.yml.j2",
-        "download/fiber/0.8.0/fnn",
+        "download/fiber/0.8.1/fnn",
     )
 
     V070_DEV = (

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,6 +1,6 @@
 set -ex
 
-DEFAULT_FIBER_BRANCH="v0.8.0"
+DEFAULT_FIBER_BRANCH="v0.8.1"
 DEFAULT_FIBER_URL="https://github.com/nervosnetwork/fiber.git"
 
 GitFIBERBranch="${GitBranch:-$DEFAULT_FIBER_BRANCH}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将集成测试仓库中与 Fiber 相关的默认/引用版本从 **0.8.0** 对齐到 **0.8.1**，与当前基线分支 `v0.8.1` 一致。

## 变更说明

- **`prepare.sh`**：`DEFAULT_FIBER_BRANCH` 由 `v0.8.0` 改为 `v0.8.1`，本地从源码构建 Fiber 时默认检出对应标签。
- **`framework/test_fiber.py`**：`CURRENT_MAINNET` / `CURRENT_TESTNET` 使用的预置二进制路径由 `download/fiber/0.8.0/fnn` 改为 `download/fiber/0.8.1/fnn`。
- **`download_fiber.py`**：在可下载版本列表中增加 `0.8.1`（保留 `0.8.0` 以便需要时仍可拉取历史包）。

## 验证

未运行完整集成测试（环境依赖较重）。若 CI 或本地使用 `download_fiber` / `prepare.sh`，请确认 `download/fiber/0.8.1/` 目录下已放置对应 `fnn` 二进制或通过脚本下载。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-039d73cc-bd3c-4936-8a1c-e09d7538df80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-039d73cc-bd3c-4936-8a1c-e09d7538df80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

