### PR TITLE
[codex] Default Fiber branch to develop

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -1,6 +1,6 @@
 set -ex
 
-DEFAULT_FIBER_BRANCH="v0.9.0-rc2"
+DEFAULT_FIBER_BRANCH="develop"
 DEFAULT_FIBER_URL="https://github.com/nervosnetwork/fiber.git"
 
 GitFIBERBranch="${GitBranch:-$DEFAULT_FIBER_BRANCH}"


### PR DESCRIPTION
## Summary

- Update `prepare.sh` so the default Fiber branch is `develop`.
- Keep the change scoped to the existing `make prepare` clone/build path.

## Motivation

GitHub Actions `workflow_dispatch` already defaults `GitBranch` to `develop`. However, runs that do not pass `GitBranch` still use the fallback in `prepare.sh`, which was `v0.9.0-rc2`. Updating that fallback makes the default prepared Fiber binary track `nervosnetwork/fiber` develop.

## Validation

- `bash -n prepare.sh`
- `git diff --check`
