### PR TITLE
Add v0.9.0 regression coverage

### DIFF
--- a/.github/workflows/fiber.yml
+++ b/.github/workflows/fiber.yml
@@ -651,6 +651,42 @@ jobs:
           name: jfoa-fiber_open_channel_with_external_funding_mixed-reports-${{ runner.os }}
           path: ./report
 
+  fiber_test_migration:
+    needs: prepare
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Download prepare backup
+        uses: actions/download-artifact@v4
+        with:
+          name: prepare-backup-${{ runner.os }}
+          path: ./
+
+      - name: Extract tarball and restore permissions
+        run: |
+          tar -xzf prepare-backup.tar.gz
+
+      - name: Run migration tests
+        run: make fiber_test_demo FIBER_TEST_DEMO="test_cases/fiber/devnet/migration"
+
+      - name: Publish reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfoa-migration-reports-${{ runner.os }}
+          path: ./report
+
   fiber_test_fnn_cli:
     needs: prepare
     runs-on: ubuntu-22.04
@@ -731,4 +767,3 @@ jobs:
         with:
           name: jfoa-proxy-tor-reports-${{ runner.os }}
           path: ./report
-

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ fiber_test_cases := \
 	test_cases/fiber/devnet/shutdown_channel \
 	test_cases/fiber/devnet/update_channel \
 	test_cases/fiber/devnet/issue \
+	test_cases/fiber/devnet/migration \
 	test_cases/fiber/devnet/watch_tower \
 	test_cases/fiber/devnet/fee_stats \
 	test_cases/fiber/devnet/fnn-cli

--- a/download_fiber.py
+++ b/download_fiber.py
@@ -18,6 +18,7 @@ versions = [
     "0.7.1",
     "0.8.0",
     "0.8.1",
+    "0.9.0-rc2",
 ]
 
 DOWNLOAD_DIR = "download/fiber"
@@ -42,7 +43,7 @@ SYSTEMS = {
         },
         "arm64": {
             "url": "https://github.com/nervosnetwork/fiber/releases/download/v{version}/fnn_v{"
-            "version}-x86_64-darwin-portable.tar.gz",
+            "version}-aarch64-darwin-portable.tar.gz",
             "ext": ".tar.gz",
         },
     },

--- a/framework/basic.py
+++ b/framework/basic.py
@@ -46,9 +46,13 @@ class CkbTest(ABC, unittest.TestCase):
         if not self.did_pass:
             print("back log data")
             try:
+                dst = f"{get_project_root()}/report/{method.__name__}"
+                # Remove any previous run's report so we never inspect stale
+                # logs after a re-run.
+                shutil.rmtree(dst, ignore_errors=True)
                 shutil.copytree(
                     f"{get_project_root()}/tmp",
-                    f"{get_project_root()}/report/{method.__name__}",
+                    dst,
                 )
             except OSError as e:
                 print("Error: %s - %s." % (e.filename, e.strerror))

--- a/framework/test_fiber.py
+++ b/framework/test_fiber.py
@@ -1,3 +1,4 @@
+import fcntl
 import shutil
 import socket
 from enum import Enum
@@ -58,17 +59,22 @@ class FiberConfigPath(Enum):
 
     CURRENT_MAINNET = (
         "/source/template/fiber/mainnet_config_3.yml.j2",
-        "download/fiber/0.8.1/fnn",
+        "download/fiber/0.9.0/fnn",
     )
 
     CURRENT_TESTNET = (
         "/source/template/fiber/testnet_config_3.yml.j2",
-        "download/fiber/0.8.1/fnn",
+        "download/fiber/0.9.0/fnn",
     )
 
     V070_DEV = (
         "/source/fiber/dev_config_3.yml.j2",
         "download/fiber/0.7.0/fnn",
+    )
+
+    V081_DEV = (
+        "/source/fiber/dev_config_3.yml.j2",
+        "download/fiber/0.8.1/fnn",
     )
 
     V061_DEV = (
@@ -231,6 +237,30 @@ class Fiber:
             False,
         )
         wait_for_port(self.rpc_port, timeout=30, open=False)
+        self._wait_store_lock_released()
+
+    def _wait_store_lock_released(self, timeout=30):
+        """After the RPC port closes the fnn process may still be flushing
+        RocksDB and holding ``<tmp_path>/fiber/store/LOCK``. If start() is
+        called too soon the new process loses the race for the lock and exits
+        with "Resource temporarily unavailable". Poll the lock until it is
+        actually released so subsequent start() is safe."""
+        lock_path = f"{self.tmp_path}/fiber/store/LOCK"
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                fd = open(lock_path, "r+")
+            except FileNotFoundError:
+                return
+            try:
+                fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.lockf(fd, fcntl.LOCK_UN)
+                return
+            except (BlockingIOError, OSError):
+                time.sleep(0.5)
+            finally:
+                fd.close()
+        raise TimeoutError(f"RocksDB LOCK still held at {lock_path} after {timeout}s")
 
     def force_stop(self):
         # run_command(f"kill -9 $(lsof -t -i:{self.rpc_port} | head -1)", False)

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,6 +1,6 @@
 set -ex
 
-DEFAULT_FIBER_BRANCH="v0.8.1"
+DEFAULT_FIBER_BRANCH="develop"
 DEFAULT_FIBER_URL="https://github.com/nervosnetwork/fiber.git"
 
 GitFIBERBranch="${GitBranch:-$DEFAULT_FIBER_BRANCH}"
@@ -15,6 +15,6 @@ cp target/debug/fnn-cli ../download/fiber/current/fnn-cli.debug
 cargo build --release
 cp target/release/fnn ../download/fiber/current/fnn
 cp target/release/fnn-cli ../download/fiber/current/fnn-cli
-cd migrate
-cargo build --release
-cp target/release/fnn-migrate ../../download/fiber/current/fnn-migrate
+# cd migrate
+# cargo build --release
+# cp target/release/fnn-migrate ../../download/fiber/current/fnn-migrate

--- a/test_cases/fiber/devnet/migration/_helpers.py
+++ b/test_cases/fiber/devnet/migration/_helpers.py
@@ -1,0 +1,305 @@
+"""Shared helpers for the PR #1323 (Unified Migration System) regression tests.
+
+These tests cover the new auto-migration flow introduced in fnn v0.9.x:
+- A `fnn` binary built after PR #1323 no longer ships a standalone `fnn-migrate`
+  for migrations >= INIT_DB_VERSION; instead it auto-migrates on startup with a
+  confirm/progress callback (`MigrateConfirmFn` / `MigrateProgressFn`).
+- For databases older than INIT_DB_VERSION (anything from <= v0.7.x), the user
+  must first run the legacy `fnn-migrate` from the v0.8.x release line.
+- The first migration that runs through the new system is the channel actor data
+  migration (0.8.1 -> 0.9.0-rc2), which adds `connectivity_state` and
+  `external_funding` fields to every persisted `ChannelActorData`.
+
+Helpers in this file deliberately stay shell-driven so that they exercise
+exactly what a real operator would do (`echo y | fnn ...`).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import requests
+
+from framework.basic_fiber import FiberTest, XUDT_TX_HASH
+from framework.config import DEFAULT_MIN_DEPOSIT_CKB
+from framework.helper.udt_contract import UdtContract
+from framework.util import get_project_root
+
+MIG_VERSION_KEY_FILE_HINT = "db-version"
+INIT_DB_VERSION = "20260302100001"
+LATEST_DB_VERSION_AFTER_PR1323 = "20260518120000"
+
+
+class MigrationFiberTest(FiberTest):
+    """FiberTest variant for migration tests that start their own nodes."""
+
+    def setup_method(self, method):
+        print("setup_method")
+        self.did_pass = None
+        self.beginNum = hex(self.node.getClient().get_tip_block_number())
+        self.fibers = []
+        self.new_fibers = []
+        self.udtContract = UdtContract(XUDT_TX_HASH, 0)
+        if self.debug:
+            return
+        self.node.getClient().clear_tx_pool()
+        self.node.start_miner()
+        self.logger.debug(f"\nSetting up method:{method.__name__}")
+
+
+def fiber_store_dir(fiber) -> Path:
+    """Path to the RocksDB store directory of a Fiber node."""
+    return Path(fiber.tmp_path) / "fiber" / "store"
+
+
+def node_log_path(fiber) -> Path:
+    return Path(fiber.tmp_path) / "node.log"
+
+
+def read_node_log(fiber) -> str:
+    p = node_log_path(fiber)
+    if not p.exists():
+        return ""
+    return p.read_text(errors="replace")
+
+
+def assert_log_contains(fiber, needle: str):
+    log = read_node_log(fiber)
+    assert needle in log, (
+        f"expected substring not found in node.log: {needle!r}\n"
+        f"--- log tail ---\n{log[-4000:]}"
+    )
+
+
+def assert_log_matches(fiber, pattern: str):
+    log = read_node_log(fiber)
+    assert re.search(pattern, log), (
+        f"expected regex not matched in node.log: {pattern!r}\n"
+        f"--- log tail ---\n{log[-4000:]}"
+    )
+
+
+def wait_log_matches(fiber, pattern: str, timeout=20):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        log = read_node_log(fiber)
+        if re.search(pattern, log):
+            return
+        time.sleep(0.2)
+    assert_log_matches(fiber, pattern)
+
+
+def fiber_bin_exists(rel_path: str) -> bool:
+    return os.path.isfile(os.path.join(get_project_root(), rel_path))
+
+
+def rpc_call_with_timeout(fiber, method, params, timeout=10):
+    response = requests.post(
+        f"http://127.0.0.1:{fiber.rpc_port}",
+        json={"id": 42, "jsonrpc": "2.0", "method": method, "params": params},
+        headers={"content-type": "application/json"},
+        timeout=timeout,
+    ).json()
+    if "error" in response:
+        raise Exception(response["error"].get("message", response["error"]))
+    return response.get("result")
+
+
+def list_channels_with_timeout(fiber, timeout=10):
+    return rpc_call_with_timeout(fiber, "list_channels", [{}], timeout)["channels"]
+
+
+def wait_peer_connected(fiber, min_count=1, timeout=10):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        peers = fiber.get_client().list_peers()["peers"]
+        if len(peers) >= min_count:
+            return peers
+        time.sleep(0.2)
+    peers = fiber.get_client().list_peers()["peers"]
+    raise TimeoutError(
+        "expected at least {} connected peers, got {}".format(min_count, peers)
+    )
+
+
+def wait_channels_ready(fiber, expected_count=1, timeout=60):
+    ready_states = {"ChannelReady", "CHANNEL_READY"}
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        channels = list_channels_with_timeout(fiber)
+        ready = [c for c in channels if c["state"]["state_name"] in ready_states]
+        if len(ready) >= expected_count:
+            return channels
+        time.sleep(1)
+    channels = list_channels_with_timeout(fiber)
+    raise TimeoutError(
+        "expected at least {} ready channels, got {}".format(expected_count, channels)
+    )
+
+
+def open_v070_channel(opener, balance):
+    peer_id = opener.get_client().list_peers()["peers"][0]["peer_id"]
+    opener.get_client().open_channel(
+        {
+            "peer_id": peer_id,
+            "funding_amount": hex(balance + DEFAULT_MIN_DEPOSIT_CKB),
+            "public": True,
+        }
+    )
+
+
+def send_invoice_payment_with_timeout(test_case, fiber1, fiber2, amount, timeout=45):
+    invoice = rpc_call_with_timeout(
+        fiber2,
+        "new_invoice",
+        [
+            {
+                "amount": hex(amount),
+                "currency": "Fibd",
+                "description": "migration liveness check invoice",
+                "payment_preimage": test_case.generate_random_preimage(),
+                "hash_algorithm": "sha256",
+                "allow_mpp": True,
+            }
+        ],
+    )
+    payment = rpc_call_with_timeout(
+        fiber1,
+        "send_payment",
+        [
+            {
+                "invoice": invoice["invoice_address"],
+                "allow_self_payment": True,
+                "max_parts": hex(12),
+                "max_fee_rate": hex(1000000000000000),
+            }
+        ],
+    )
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = rpc_call_with_timeout(
+            fiber1,
+            "get_payment",
+            [{"payment_hash": payment["payment_hash"]}],
+        )
+        if result["status"] == "Success":
+            return payment["payment_hash"]
+        if result["status"] == "Failed":
+            raise Exception(f"payment failed: {result}")
+        time.sleep(1)
+    raise TimeoutError(
+        "payment:{} status did not reach Success within {}s".format(
+            payment["payment_hash"], timeout
+        )
+    )
+
+
+def send_invoice_payment_with_retry(test_case, fiber1, fiber2, amount, timeout=60):
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            return send_invoice_payment_with_timeout(
+                test_case, fiber1, fiber2, amount, timeout=15
+            )
+        except Exception as e:
+            last_error = e
+            time.sleep(1)
+    raise TimeoutError(f"payment did not succeed within {timeout}s: {last_error}")
+
+
+def start_with_confirm(
+    fiber,
+    confirm="y",
+    password="password0",
+    fnn_log_level="debug",
+    timeout=300,
+):
+    """Start fnn and answer the migration confirm prompt.
+
+    This is local to migration tests because normal Fiber tests should keep
+    using `fiber.start()`.
+    """
+    env = os.environ.copy()
+    env["FIBER_SECRET_KEY_PASSWORD"] = password
+    env["RUST_LOG"] = f"info,fnn={fnn_log_level}"
+    log_path = node_log_path(fiber)
+    cmd = [
+        f"{get_project_root()}/{fiber.fiber_config_enum.fiber_bin_path}",
+        "-c",
+        f"{fiber.tmp_path}/config.yml",
+        "-d",
+        fiber.tmp_path,
+    ]
+
+    log_file = open(log_path, "ab")
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    log_file.close()
+
+    if proc.stdin is not None:
+        try:
+            proc.stdin.write(f"{confirm}\n".encode())
+            proc.stdin.close()
+        except BrokenPipeError:
+            pass
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(1)
+            if s.connect_ex(("127.0.0.1", int(fiber.rpc_port))) == 0:
+                return
+
+        exit_code = proc.poll()
+        if exit_code is not None:
+            raise RuntimeError(
+                f"Fiber exited before RPC port {fiber.rpc_port} opened "
+                f"(exit code {exit_code}).\n--- node.log tail ---\n"
+                f"{read_node_log(fiber)[-4000:]}"
+            )
+        time.sleep(0.3)
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    raise TimeoutError(
+        f"Port {fiber.rpc_port} did not become open within {timeout}s.\n"
+        f"--- node.log tail ---\n{read_node_log(fiber)[-4000:]}"
+    )
+
+
+def start_blocking(
+    fiber,
+    confirm="n",
+    password="password0",
+    fnn_log_level="info",
+    timeout=60,
+):
+    cmd = (
+        f"echo {confirm} | FIBER_SECRET_KEY_PASSWORD='{password}' "
+        f"RUST_LOG=info,fnn={fnn_log_level} "
+        f"{get_project_root()}/{fiber.fiber_config_enum.fiber_bin_path} "
+        f"-c {fiber.tmp_path}/config.yml -d {fiber.tmp_path}"
+    )
+    proc = subprocess.run(
+        cmd,
+        shell=True,
+        timeout=timeout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    out = proc.stdout.decode("utf-8", errors="replace") if proc.stdout else ""
+    return proc.returncode, out

--- a/test_cases/fiber/devnet/migration/test_auto_migrate_from_v081.py
+++ b/test_cases/fiber/devnet/migration/test_auto_migrate_from_v081.py
@@ -1,0 +1,96 @@
+"""PR #1323/#1355 regression: auto-migrate from v0.8.1 to current.
+
+Scenario:
+  1. Start a pair of v0.8.1 fnn nodes, open a channel, exchange payments so the
+     RocksDB store contains real ChannelActorData (old layout).
+  2. Stop both nodes.
+  3. Switch the binary to current WITHOUT running the old
+     standalone `fnn-migrate` tool.
+  4. Start each node again. The new auto-migration must:
+       - present a confirmation prompt on stderr (we pipe "y"),
+       - run the latest channel actor data migration against the existing
+         ChannelActorData entries,
+       - leave db-version at LATEST_DB_VERSION_AFTER_PR1323.
+  5. After both nodes are up, the channel must still be alive and a fresh
+     payment must succeed in both directions.
+"""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    send_invoice_payment_with_timeout,
+    start_with_confirm,
+    wait_log_matches,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestAutoMigrateFromV081(MigrationFiberTest):
+    def test_auto_migrate_v081_to_current(self):
+        # 1. start two v0.8.1 nodes
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+
+        # 2. open a public channel and exercise it so ChannelActorData is on disk
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0)
+        self.send_invoice_payment(old_a, old_b, 1)
+        self.send_invoice_payment(old_b, old_a, 1)
+
+        old_channel_count = len(old_a.get_client().list_channels({})["channels"])
+        assert old_channel_count >= 1
+
+        old_a.stop()
+        old_b.stop()
+
+        # 3. switch binary to current WITHOUT running fnn-migrate
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+
+        # 4. start with auto-confirm; auto-migration must succeed
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+
+        # the migration plan + step messages should have been logged
+        wait_log_matches(old_a, r"Database migration required")
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(
+            old_a, r"Migration {} complete".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_a, r"connectivity_state and external_funding")
+
+        # 5. channel survived the migration and is still usable via RPC
+        chans = list_channels_with_timeout(old_a)
+        assert len(chans) == old_channel_count, "channel must survive migration"
+        assert all(c["state"]["state_name"] == "ChannelReady" for c in chans), chans
+
+        # 6. fresh payments must work in both directions
+        send_invoice_payment_with_timeout(self, old_a, old_b, 1)
+        send_invoice_payment_with_timeout(self, old_b, old_a, 1)
+
+        # 7. starting again should NOT trigger another migration
+        old_a.stop()
+        start_with_confirm(old_a, confirm="y")
+        log = open(f"{old_a.tmp_path}/node.log").read()
+        # after a clean second startup we expect the "is current, no migration
+        # needed" branch (or at least no new "Migrating to" line for the same
+        # version a second time)
+        assert (
+            log.count("Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)) == 1
+        ), "auto-migration must be idempotent on second startup"

--- a/test_cases/fiber/devnet/migration/test_large_u128_channel_constraints.py
+++ b/test_cases/fiber/devnet/migration/test_large_u128_channel_constraints.py
@@ -1,0 +1,89 @@
+"""PR #1355 regression: explicit large u128 channel constraints must migrate.
+
+This covers the bug class fixed by avoiding JSON round-trips in channel data
+migration. A v0.8.1 channel can persist u128-sized constraint fields; current
+fnn must migrate that data and still read the channel normally.
+"""
+
+import time
+
+import pytest
+
+from framework.config import DEFAULT_MIN_DEPOSIT_CKB
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    send_invoice_payment_with_timeout,
+    start_with_confirm,
+    wait_log_matches,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestLargeU128ChannelConstraints(MigrationFiberTest):
+    def test_auto_migrate_v081_explicit_max_tlc_value_in_flight(self):
+        large_max_tlc_value = (1 << 128) - 1
+
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a)
+
+        temporary_channel = old_a.get_client().open_channel(
+            {
+                "pubkey": old_b.get_pubkey(),
+                "funding_amount": hex(DEFAULT_MIN_DEPOSIT_CKB + 10 * 100000000),
+                "public": True,
+                "max_tlc_value_in_flight": hex(large_max_tlc_value),
+            }
+        )
+        time.sleep(1)
+        old_b.get_client().accept_channel(
+            {
+                "temporary_channel_id": temporary_channel["temporary_channel_id"],
+                "funding_amount": hex(1000 * 100000000),
+                "max_tlc_value_in_flight": hex(large_max_tlc_value),
+            }
+        )
+        self.wait_for_channel_state(
+            old_a.get_client(), old_b.get_pubkey(), "ChannelReady"
+        )
+
+        self.send_invoice_payment(old_a, old_b, 1, False)
+        self.send_invoice_payment(old_b, old_a, 1, False)
+        old_channel_count = len(old_a.get_client().list_channels({})["channels"])
+        assert old_channel_count >= 1
+
+        old_a.stop()
+        old_b.stop()
+
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_a, r"connectivity_state and external_funding")
+
+        chans = list_channels_with_timeout(old_a)
+        assert len(chans) == old_channel_count, "channel must survive migration"
+        assert all(c["state"]["state_name"] == "ChannelReady" for c in chans), chans
+
+        send_invoice_payment_with_timeout(self, old_a, old_b, 1)
+        send_invoice_payment_with_timeout(self, old_b, old_a, 1)

--- a/test_cases/fiber/devnet/migration/test_legacy_migrate_archived.py
+++ b/test_cases/fiber/devnet/migration/test_legacy_migrate_archived.py
@@ -1,0 +1,37 @@
+"""PR #1323 archive sanity: the legacy `fnn-migrate` binary must NOT be shipped
+inside the v0.9.0+ release tarball anymore (the `migrate/` workspace was renamed
+to `migrate_archive/` and removed from CI). The v0.8.x release line keeps it.
+
+This test asserts the on-disk layout that download_fiber.py extracts.
+"""
+
+import os
+
+import pytest
+
+from framework.util import get_project_root
+
+
+def _exists(rel: str) -> bool:
+    return os.path.isfile(os.path.join(get_project_root(), rel))
+
+
+class TestLegacyMigrateArchived:
+    def test_v081_release_still_ships_fnn_migrate(self):
+        if not _exists("download/fiber/0.8.1/fnn"):
+            pytest.skip("v0.8.1 not downloaded")
+        assert _exists(
+            "download/fiber/0.8.1/fnn-migrate"
+        ), "v0.8.1 release MUST keep fnn-migrate (used as the bridge tool)"
+
+    def test_current_release_no_longer_ships_fnn_migrate(self):
+        if not _exists("download/fiber/current/fnn"):
+            pytest.skip("current binary not downloaded")
+        # PR #1323 archives the standalone tool. If a future release brings it
+        # back, this test will flip to a green dot once the assertion is
+        # inverted -- but for now its absence is part of the contract.
+        assert not _exists("download/fiber/current/fnn-migrate"), (
+            "PR #1323 removed standalone fnn-migrate from the new release; "
+            "found it again under download/fiber/current/. "
+            "If this is intentional, update this assertion."
+        )

--- a/test_cases/fiber/devnet/migration/test_multi_channel_migration.py
+++ b/test_cases/fiber/devnet/migration/test_multi_channel_migration.py
@@ -1,0 +1,68 @@
+"""PR #1355 regression: multiple channel actor records migrate together."""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    send_invoice_payment_with_retry,
+    start_with_confirm,
+    wait_log_matches,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestMultiChannelMigration(MigrationFiberTest):
+    def test_auto_migrate_v081_three_node_route(self):
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_c = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0)
+        self.open_channel(old_b, old_c, 1000 * 100000000, 0)
+        send_invoice_payment_with_retry(self, old_a, old_c, 1)
+
+        old_b_channel_count = len(old_b.get_client().list_channels({})["channels"])
+        assert old_b_channel_count >= 2
+
+        old_a.stop()
+        old_b.stop()
+        old_c.stop()
+
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_c.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+        start_with_confirm(old_c, confirm="y")
+        old_a.connect_peer(old_b)
+        old_b.connect_peer(old_c)
+        wait_peer_connected(old_a)
+        wait_peer_connected(old_b)
+
+        wait_log_matches(
+            old_b, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_b, r"connectivity_state and external_funding")
+
+        channels = list_channels_with_timeout(old_b)
+        assert len(channels) == old_b_channel_count, "all channels must survive"
+        assert all(c["state"]["state_name"] == "ChannelReady" for c in channels)
+
+        send_invoice_payment_with_retry(self, old_a, old_c, 1)

--- a/test_cases/fiber/devnet/migration/test_new_db_stamps_latest.py
+++ b/test_cases/fiber/devnet/migration/test_new_db_stamps_latest.py
@@ -1,0 +1,41 @@
+"""PR #1323 regression: a brand-new database (no `db-version` key) must be
+stamped with LATEST_DB_VERSION on first open and must NOT prompt the user.
+A second start must be a no-op (`Database version ... is current, no migration
+needed`).
+"""
+
+from ._helpers import (
+    fiber_store_dir,
+    MigrationFiberTest,
+    read_node_log,
+    start_with_confirm,
+)
+
+
+class TestNewDbStampsLatest(MigrationFiberTest):
+    def test_new_db_no_migration_needed(self):
+        fiber = self.start_new_fiber(self.account1_private_key)
+
+        # The current binary started against an empty data dir, so the
+        # auto_migrate "no db-version -> stamp LATEST" branch must have run.
+        store = fiber_store_dir(fiber)
+        assert store.exists(), "fiber1 store must exist after first startup"
+
+        # No migration plan / progress lines should appear in the log because
+        # the DB is brand-new.
+        log1 = read_node_log(fiber)
+        assert "Database migration required" not in log1
+        assert "Migrating to" not in log1
+
+        # Second startup must hit the "is current, no migration needed" branch.
+        fiber.stop()
+        start_with_confirm(fiber, confirm="n")  # would cancel if asked
+
+        log2 = read_node_log(fiber)
+        assert (
+            "Database migration required" not in log2
+        ), "auto_migrate must NOT prompt when db-version already equals LATEST"
+        # the framework startup may or may not log the exact phrase; the strong
+        # contract is: the node is up and answering RPC.
+        info = fiber.get_client().node_info()
+        assert "node_id" in info or "pubkey" in info

--- a/test_cases/fiber/devnet/migration/test_newer_db_rejected.py
+++ b/test_cases/fiber/devnet/migration/test_newer_db_rejected.py
@@ -1,0 +1,49 @@
+"""PR #1323 sanity check: starting against an artificially "future" db-version
+must abort with `MigrateError::DatabaseTooNew` instead of silently downgrading
+the user.
+
+We simulate a future db-version by directly writing into RocksDB after stopping
+the node. To stay backend-agnostic, we only assert on the user-visible behavior
+(non-zero exit + `too new` / "newer" diagnostic), not on the exact RocksDB key
+format.
+
+If your CI doesn't ship `python-rocksdb`, this test is automatically skipped.
+"""
+
+import pytest
+
+from ._helpers import (
+    fiber_store_dir,
+    MigrationFiberTest,
+    read_node_log,
+    start_blocking,
+)
+
+rocksdb = pytest.importorskip(
+    "rocksdict",
+    reason="rocksdict not installed; install with `pip install rocksdict` to run",
+)
+
+
+class TestNewerDbRejected(MigrationFiberTest):
+    def test_future_db_version_rejected(self):
+        # Start current fnn against a fresh DB, then stop it so we can rewrite
+        # db-version to a future value.
+        fiber = self.start_new_fiber(self.account1_private_key)
+        fiber.stop()
+
+        # write a future db-version into the RocksDB store directly
+        future_version = "29991231235959"
+        store_path = str(fiber_store_dir(fiber))
+        db = rocksdb.Rdict(store_path)
+        try:
+            db[b"db-version"] = future_version.encode()
+        finally:
+            db.close()
+
+        exit_code, output = start_blocking(fiber, confirm="y", timeout=60)
+        assert exit_code != 0, "fnn must NOT start when db is newer than binary"
+        log = output + "\n" + read_node_log(fiber)
+        assert (
+            "newer" in log.lower() or "too new" in log.lower() or future_version in log
+        ), f"expected DatabaseTooNew diagnostic, got:\n{log[-2000:]}"

--- a/test_cases/fiber/devnet/migration/test_old_db_rejected.py
+++ b/test_cases/fiber/devnet/migration/test_old_db_rejected.py
@@ -1,0 +1,68 @@
+"""PR #1323 regression: starting current fnn against an old (< INIT_DB_VERSION)
+database must fail fast with a clear `DatabaseTooOld` style message instead of
+silently corrupting the store or hanging.
+
+We use a v0.7.0 database, since its highest db-version is well below
+INIT_DB_VERSION = 20260302100001.
+"""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    INIT_DB_VERSION,
+    fiber_bin_exists,
+    MigrationFiberTest,
+    open_v070_channel,
+    read_node_log,
+    start_blocking,
+    wait_channels_ready,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.7.0/fnn"),
+    reason="v0.7.0 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestOldDbRejected(MigrationFiberTest):
+    def test_v070_db_directly_against_current_is_rejected(self):
+        # 1. produce a real v0.7.0 store
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V070_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V070_DEV
+        )
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a)
+        open_v070_channel(old_a, 1000 * 100000000)
+        wait_channels_ready(old_a)
+        old_a.stop()
+        old_b.stop()
+
+        # 2. switch to current binary WITHOUT running v0.8.x fnn-migrate
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+
+        # 3. starting must fail. We pipe "y" so that, if for some reason the
+        #    binary still asks for confirmation, we are not the cause of the
+        #    failure. The expected exit comes from MigrateError::DatabaseTooOld.
+        exit_code, output = start_blocking(old_a, confirm="y", timeout=60)
+        assert exit_code != 0, "fnn must NOT start against a pre-INIT_DB_VERSION DB"
+
+        log = output + "\n" + read_node_log(old_a)
+        # message format from MigrateError::DatabaseTooOld
+        assert (
+            "too old" in log.lower()
+            or INIT_DB_VERSION in log
+            or "fnn-migrate" in log.lower()
+        ), f"expected DatabaseTooOld diagnostic, got log:\n{log[-2000:]}"
+
+        # the user-facing hint should point at the correct legacy tool version
+        # (design says v0.7.x, current code says v0.8.x -- this assertion
+        # locks the contract; flip the literal if the project chooses one).
+        assert (
+            "v0.7" in log or "v0.8" in log
+        ), "DatabaseTooOld must point users at the legacy fnn-migrate version"

--- a/test_cases/fiber/devnet/migration/test_pending_hold_invoice_migration.py
+++ b/test_cases/fiber/devnet/migration/test_pending_hold_invoice_migration.py
@@ -1,0 +1,84 @@
+"""PR #1355 regression: pending TLC state can be resumed after migration."""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+from test_cases.fiber.devnet.settle_invoice.test_settle_invoice import sha256_hex
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    start_with_confirm,
+    wait_log_matches,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestPendingHoldInvoiceMigration(MigrationFiberTest):
+    def test_auto_migrate_v081_pending_hold_invoice(self):
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0)
+        preimage = self.generate_random_preimage()
+        payment_hash = sha256_hex(preimage)
+        invoice = old_b.get_client().new_invoice(
+            {
+                "amount": hex(1 * 100000000),
+                "currency": "Fibd",
+                "description": "migration hold invoice",
+                "expiry": hex(3600),
+                "final_cltv": hex(40),
+                "payment_hash": payment_hash,
+                "hash_algorithm": "sha256",
+            }
+        )
+        payment = old_a.get_client().send_payment(
+            {"invoice": invoice["invoice_address"]}
+        )
+        self.wait_invoice_state(old_b, payment_hash, "Received", 120, 1)
+        old_channels = old_a.get_client().list_channels({})["channels"]
+        assert len(old_channels[0]["pending_tlcs"]) >= 1
+
+        old_a.stop()
+        old_b.stop()
+
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a)
+
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_a, r"connectivity_state and external_funding")
+
+        channels = list_channels_with_timeout(old_a)
+        assert len(channels) == len(old_channels), "channel must survive migration"
+        assert channels[0]["state"]["state_name"] == "ChannelReady"
+
+        invoice_after_restart = old_b.get_client().get_invoice(
+            {"payment_hash": payment_hash}
+        )
+        assert invoice_after_restart["status"] == "Received"
+
+        old_b.get_client().settle_invoice(
+            {"payment_hash": payment_hash, "payment_preimage": preimage}
+        )
+        self.wait_payment_state(old_a, payment["payment_hash"], "Success", 120, 1)
+        invoice_paid = old_b.get_client().get_invoice({"payment_hash": payment_hash})
+        assert invoice_paid["status"] == "Paid"

--- a/test_cases/fiber/devnet/migration/test_two_step_upgrade_from_v070.py
+++ b/test_cases/fiber/devnet/migration/test_two_step_upgrade_from_v070.py
@@ -1,0 +1,75 @@
+"""PR #1323/#1355 regression: the documented two-step upgrade path
+v0.7.0 -> (run v0.8.x `fnn-migrate`) -> current must succeed end-to-end.
+
+This is the upgrade path PR #1323 explicitly preserves: pre-INIT_DB_VERSION
+databases must first be brought up to INIT_DB_VERSION using the legacy
+standalone migrate tool from a v0.8.x release, then the current binary's
+auto-migration takes over for everything from INIT_DB_VERSION onward
+(currently the channel actor data migration).
+"""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    open_v070_channel,
+    send_invoice_payment_with_timeout,
+    start_with_confirm,
+    wait_channels_ready,
+    wait_log_matches,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not (
+        fiber_bin_exists("download/fiber/0.7.0/fnn")
+        and fiber_bin_exists("download/fiber/0.8.1/fnn-migrate")
+    ),
+    reason="v0.7.0 fnn and v0.8.1 fnn-migrate must both be present",
+)
+
+
+class TestTwoStepUpgradeFromV070(MigrationFiberTest):
+    def test_v070_then_v081_migrate_then_current_autostart(self):
+        # 1. v0.7.0 phase: real channel data on disk
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V070_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V070_DEV
+        )
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a)
+        open_v070_channel(old_a, 1000 * 100000000)
+        wait_channels_ready(old_a)
+        self.send_invoice_payment(old_a, old_b, 1)
+        self.send_invoice_payment(old_b, old_a, 1)
+        old_a.stop()
+        old_b.stop()
+
+        # 2. step 1 of upgrade: legacy fnn-migrate from v0.8.1
+        old_a.fiber_config_enum = FiberConfigPath.V081_DEV
+        old_b.fiber_config_enum = FiberConfigPath.V081_DEV
+        old_a.migration()
+        old_b.migration()
+
+        # 3. step 2 of upgrade: switch to current and let auto-migrate finish
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+
+        # 4. liveness checks
+        chans = list_channels_with_timeout(old_a)
+        assert len(chans) >= 1, "channel must survive the two-step upgrade"
+        send_invoice_payment_with_timeout(self, old_a, old_b, 1)
+        send_invoice_payment_with_timeout(self, old_b, old_a, 1)

--- a/test_cases/fiber/devnet/migration/test_udt_channel_migration.py
+++ b/test_cases/fiber/devnet/migration/test_udt_channel_migration.py
@@ -1,0 +1,58 @@
+"""PR #1355 regression: UDT channel data must survive auto-migration."""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    start_with_confirm,
+    wait_log_matches,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestUdtChannelMigration(MigrationFiberTest):
+    def test_auto_migrate_v081_udt_channel(self):
+        udt_script = self.get_account_udt_script(self.account1_private_key)
+        old_a = self.start_new_fiber(
+            self.generate_account(10000, self.account1_private_key, 2000 * 100000000),
+            fiber_version=FiberConfigPath.V081_DEV,
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0, udt=udt_script)
+        self.send_payment(old_a, old_b, 1 * 100000000, udt=udt_script)
+        old_channels = old_a.get_client().list_channels({})["channels"]
+        assert len(old_channels) >= 1
+        assert old_channels[0]["funding_udt_type_script"] == udt_script
+
+        old_a.stop()
+        old_b.stop()
+
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_a, r"connectivity_state and external_funding")
+
+        channels = list_channels_with_timeout(old_a)
+        assert len(channels) == len(old_channels), "UDT channel must survive migration"
+        assert channels[0]["state"]["state_name"] == "ChannelReady"
+        assert channels[0]["funding_udt_type_script"] == udt_script
+
+        self.send_payment(old_a, old_b, 1 * 100000000, udt=udt_script)

--- a/test_cases/fiber/devnet/migration/test_user_cancel_migration.py
+++ b/test_cases/fiber/devnet/migration/test_user_cancel_migration.py
@@ -1,0 +1,52 @@
+"""PR #1323 regression: when the user declines the migration confirm prompt,
+fnn must abort with `MigrateError::UserCancelled` and must NOT touch the data.
+"""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    start_blocking,
+    start_with_confirm,
+    wait_channels_ready,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestUserCancelMigration(MigrationFiberTest):
+    def test_decline_migration_aborts_startup(self):
+        # 1. produce a v0.8.1 store (db-version == INIT_DB_VERSION)
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0)
+        wait_channels_ready(old_a)
+        old_a.stop()
+        old_b.stop()
+
+        # 2. switch to current and decline the prompt
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+
+        exit_code, output = start_blocking(old_a, confirm="n", timeout=60)
+        assert exit_code != 0, "fnn must NOT start when user declines migration"
+        assert (
+            "cancel" in output.lower() or "usercancelled" in output.lower()
+        ), f"expected UserCancelled in output, got:\n{output[-2000:]}"
+
+        # 3. flipping the answer to "y" on a retry must succeed and the channel
+        #    data must still be readable (the cancelled run must not have
+        #    partially written anything corrupting).
+        start_with_confirm(old_a, confirm="y")
+        chans = list_channels_with_timeout(old_a)
+        assert len(chans) >= 1, "channel must survive a previously cancelled migration"

--- a/test_cases/fiber/devnet/open_channel_with_external_funding/test_basic_flow.py
+++ b/test_cases/fiber/devnet/open_channel_with_external_funding/test_basic_flow.py
@@ -106,7 +106,15 @@ class TestExternalFundingBasicFlow(ExternalFundingBase):
     ):
         """
         T-21: before submit, the channel may be absent from list_channels or it
-        may already appear in AwaitingExternalFunding. Both are valid.
+        may already appear in the "awaiting external funding" phase.
+
+        The PR-1252 state-machine refactor folded the standalone
+        `AwaitingExternalFunding` state into
+        `NegotiatingFunding(AWAITING_EXTERNAL_FUNDING)`. So the valid
+        observable states are now:
+          * state_name == "NegotiatingFunding" with state_flags containing
+            "AWAITING_EXTERNAL_FUNDING", OR
+          * legacy "AwaitingExternalFunding" (for older binaries).
         """
         context = self._open_external_funding_channel(public=True)
         initiator_channel = self._find_channel_by_id(
@@ -119,4 +127,14 @@ class TestExternalFundingBasicFlow(ExternalFundingBase):
         for channel in (initiator_channel, acceptor_channel):
             if channel is None:
                 continue
-            assert channel["state"]["state_name"] == "AwaitingExternalFunding"
+            state = channel["state"]
+            name = state["state_name"]
+            flags = state.get("state_flags", "")
+            ok = name == "AwaitingExternalFunding" or (
+                name == "NegotiatingFunding"
+                and "AWAITING_EXTERNAL_FUNDING" in (flags or "")
+            )
+            assert ok, (
+                f"pre-submit channel should be awaiting external funding, "
+                f"got state_name={name!r}, state_flags={flags!r}"
+            )

--- a/test_cases/fiber/testnet/test_install_script.py
+++ b/test_cases/fiber/testnet/test_install_script.py
@@ -1,0 +1,738 @@
+"""PR #1262 testnet installer regression test.
+
+Default runs cover the installer/startup smoke path. The full real testnet
+channel/payment/close acceptance flow is opt-in because it opens and closes a
+real public testnet channel.
+
+Run the live flow explicitly with:
+    FIBER_PR1262_RUN_LIVE_CHANNEL=1 pytest -q \
+        test_cases/fiber/testnet/test_install_script.py::TestPR1262InstallScript::test_install_script_installs_starts_opens_channel_and_sends_payment -s
+"""
+
+import os
+import re
+import signal
+import socket
+import stat
+import subprocess
+import textwrap
+import time
+import urllib.request
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional, Tuple
+
+import pytest
+
+from framework.fiber_rpc import FiberRPCClient
+from framework.rpc import RPCClient
+from framework.test_fiber import FiberConfigPath
+from framework.util import get_project_root
+
+DEFAULT_ACCOUNT_1 = {
+    "private_key": "ff86b08163503b9583cbcf48d70de24a1cbd7178f5a0107b976862a31e4b2007",
+    "mainnet_address": "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqfqrxdlsl87hs7ggycnapc9ztxrru472cgm63u4s",
+    "testnet_address": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqfqrxdlsl87hs7ggycnapc9ztxrru472cg4g6nlg",
+    "lock_arg": "0x20199bf87cfebc3c841313e870512cc31f2be561",
+    "lock_hash": "0x4e3b33be6d88bb16ef2e651d8c104d8b71627c1ade2781df2f8193779bd5bc8f",
+}
+DEFAULT_ACCOUNT_2 = {
+    "private_key": "bb063c2683104406b492573e1aa5714f433a9dbb5849f19a0a4fca7f5b6317b8",
+    "mainnet_address": "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqf36t5upsx5m25u4pnlhkcwwx5fqlssc0g8w8s5q",
+    "testnet_address": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqf36t5upsx5m25u4pnlhkcwwx5fqlssc0gfuvl7c",
+    "lock_arg": "0x31d2e9c0c0d4daa9ca867fbdb0e71a8907e10c3d",
+    "lock_hash": "0xbd36bd29384889fa4990dde131ead4ae6cc85e4ce21dfa95b1cec36934ad1c96",
+}
+
+
+def configured_account(index, defaults):
+    private_key = os.environ.get(
+        f"FIBER_PR1262_ACCOUNT_PRIVATE_{index}", defaults["private_key"]
+    ).replace("0x", "")
+    use_defaults = private_key == defaults["private_key"]
+    return {
+        "index": index,
+        "private_key": private_key,
+        "mainnet_address": os.environ.get(
+            f"FIBER_PR1262_ACCOUNT_MAINNET_ADDRESS_{index}",
+            defaults["mainnet_address"] if use_defaults else "",
+        ),
+        "testnet_address": os.environ.get(
+            f"FIBER_PR1262_ACCOUNT_TESTNET_ADDRESS_{index}",
+            defaults["testnet_address"] if use_defaults else "",
+        ),
+        "lock_arg": os.environ.get(
+            f"FIBER_PR1262_ACCOUNT_LOCK_ARG_{index}",
+            defaults["lock_arg"] if use_defaults else "",
+        ),
+        "lock_hash": os.environ.get(
+            f"FIBER_PR1262_ACCOUNT_LOCK_HASH_{index}",
+            defaults["lock_hash"] if use_defaults else "",
+        ),
+    }
+
+
+ACCOUNT_1 = configured_account(1, DEFAULT_ACCOUNT_1)
+ACCOUNT_2 = configured_account(2, DEFAULT_ACCOUNT_2)
+ACCOUNT_PRIVATE_1 = ACCOUNT_1["private_key"]
+ACCOUNT_PRIVATE_2 = ACCOUNT_2["private_key"]
+CKB = 100000000
+PAYMENT_AMOUNT_SHANNON = 1000
+TESTNET_CKB_RPC_URL = "https://testnet.ckb.dev"
+RUN_LIVE_CHANNEL_ENV = "FIBER_PR1262_RUN_LIVE_CHANNEL"
+REFRESH_INSTALL_SH_ENV = "FIBER_PR1262_REFRESH_INSTALL_SH"
+INSTALL_SH_URL = (
+    "https://raw.githubusercontent.com/nervosnetwork/fiber/pull/1262/head"
+    "/tools/install/install.sh"
+)
+INSTALL_SH_CACHE_NAME = "nervosnetwork-fiber-pr-1262"
+_INSTALL_SH_PATH_CACHE = {}
+
+
+def install_sh_download_source():
+    return INSTALL_SH_URL, INSTALL_SH_CACHE_NAME
+
+
+def download_install_sh(url, cache_name):
+    cache_key = (url, cache_name)
+    cache_dir = Path(get_project_root()) / "download" / "fiber" / "install" / cache_name
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / "install.sh"
+    refresh = os.environ.get(REFRESH_INSTALL_SH_ENV) == "1"
+
+    cached_path = _INSTALL_SH_PATH_CACHE.get(cache_key)
+    if cached_path and cached_path.exists() and not refresh:
+        return cached_path
+
+    if path.exists() and not refresh:
+        _INSTALL_SH_PATH_CACHE[cache_key] = path
+        return path
+
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            path.write_bytes(response.read())
+    except Exception as err:
+        if path.exists():
+            _INSTALL_SH_PATH_CACHE[cache_key] = path
+            return path
+        pytest.fail(f"install.sh download failed: {url}: {err}")
+
+    _INSTALL_SH_PATH_CACHE[cache_key] = path
+    return path
+
+
+def install_sh_path():
+    return download_install_sh(*install_sh_download_source())
+
+
+def run_live_channel_test():
+    return os.environ.get(RUN_LIVE_CHANNEL_ENV) == "1"
+
+
+def local_fnn_path():
+    project_root = Path(get_project_root())
+    path = project_root / FiberConfigPath.CURRENT_TESTNET.fiber_bin_path
+    if path.exists() and (path.parent / "config" / "testnet" / "config.yml").exists():
+        return path
+
+    pytest.fail(
+        f"{FiberConfigPath.CURRENT_TESTNET.fiber_bin_path} with bundled testnet config not found"
+    )
+
+
+def free_tcp_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def write_executable(path, content):
+    path.write_text(textwrap.dedent(content).lstrip())
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def account_info_for_private_key(private_key):
+    private_key = private_key.replace("0x", "")
+    for account in (ACCOUNT_1, ACCOUNT_2):
+        if account["private_key"] == private_key:
+            missing = [
+                key
+                for key in (
+                    "mainnet_address",
+                    "testnet_address",
+                    "lock_arg",
+                    "lock_hash",
+                )
+                if not account[key]
+            ]
+            if missing:
+                missing_env_names = {
+                    "mainnet_address": f"FIBER_PR1262_ACCOUNT_MAINNET_ADDRESS_{account['index']}",
+                    "testnet_address": f"FIBER_PR1262_ACCOUNT_TESTNET_ADDRESS_{account['index']}",
+                    "lock_arg": f"FIBER_PR1262_ACCOUNT_LOCK_ARG_{account['index']}",
+                    "lock_hash": f"FIBER_PR1262_ACCOUNT_LOCK_HASH_{account['index']}",
+                }
+                pytest.fail(
+                    "custom PR1262 test account requires metadata env vars: "
+                    + ", ".join(missing_env_names[key] for key in missing)
+                )
+            return account
+    pytest.fail("no PR1262 account metadata found for the requested private key")
+
+
+def make_fake_ckb_cli(fake_bin):
+    fake_bin.mkdir()
+    ckb_cli = fake_bin / "ckb-cli"
+    write_executable(
+        ckb_cli,
+        f"""
+        #!/bin/sh
+        if [ "$1" = "account" ] && [ "$2" = "list" ]; then
+          cat <<EOF
+        - "#": 0
+          address:
+            mainnet: $STUB_CKB_MAINNET_ADDRESS
+            testnet: $STUB_CKB_TESTNET_ADDRESS
+          lock_arg: $STUB_CKB_LOCK_ARG
+          lock_hash: $STUB_CKB_LOCK_HASH
+          source: Local File System
+        EOF
+          exit 0
+        fi
+
+        if [ "$1" = "account" ] && [ "$2" = "export" ]; then
+          output=""
+          requested_lock_arg=""
+          while [ "$#" -gt 0 ]; do
+            if [ "$1" = "--lock-arg" ]; then
+              shift
+              requested_lock_arg="$1"
+            fi
+            if [ "$1" = "--extended-privkey-path" ]; then
+              shift
+              output="$1"
+            fi
+            shift
+          done
+          if [ "$requested_lock_arg" != "$STUB_CKB_LOCK_ARG" ]; then
+            echo "unknown lock_arg: $requested_lock_arg" >&2
+            exit 1
+          fi
+          mkdir -p "$(dirname "$output")"
+          printf '%s\\n' "$STUB_CKB_PRIVATE_KEY" > "$output"
+          exit 0
+        fi
+
+        echo "unexpected ckb-cli call: $*" >&2
+        exit 1
+        """,
+    )
+    return ckb_cli
+
+
+def patch_config_ports(config_path, p2p_port, rpc_port):
+    content = config_path.read_text()
+    content = re.sub(
+        r'listening_addr:\s*"/ip4/[^"]+/tcp/\d+"',
+        f'listening_addr: "/ip4/127.0.0.1/tcp/{p2p_port}"',
+        content,
+        count=1,
+    )
+    content = re.sub(
+        r'listening_addr:\s*"127\.0\.0\.1:\d+"',
+        f'listening_addr: "127.0.0.1:{rpc_port}"',
+        content,
+        count=1,
+    )
+    content = re.sub(
+        r'rpc_url:\s*"https://testnet\.ckbapp\.dev/"',
+        'rpc_url: "https://testnet.ckb.dev"',
+        content,
+    )
+    config_path.write_text(content)
+
+
+def run_installer(script, fnn, install_dir, fake_bin, tmp_path, private_key):
+    account = account_info_for_private_key(private_key)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(tmp_path / "home"),
+            "STUB_CKB_PRIVATE_KEY": private_key,
+            "STUB_CKB_MAINNET_ADDRESS": account["mainnet_address"],
+            "STUB_CKB_TESTNET_ADDRESS": account["testnet_address"],
+            "STUB_CKB_LOCK_ARG": account["lock_arg"],
+            "STUB_CKB_LOCK_HASH": account["lock_hash"],
+        }
+    )
+    (tmp_path / "home").mkdir(exist_ok=True)
+
+    return subprocess.run(
+        ["bash", str(script), "--local-binary", str(fnn), str(install_dir), "testnet"],
+        input=f"2\n{account['lock_arg']}\nn\n",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+
+
+def wait_log_contains(log_path, expected, label, timeout=150):
+    seen = {value: False for value in expected}
+    deadline = time.time() + timeout
+
+    with open(log_path) as log_file:
+        while time.time() < deadline:
+            line = log_file.readline()
+            if not line:
+                time.sleep(0.2)
+                continue
+
+            print(f"[{label}] {line}", end="", flush=True)
+            for value in expected:
+                if value in line:
+                    seen[value] = True
+
+            if all(seen.values()):
+                return log_path.read_text()
+
+    full_output = log_path.read_text()
+    assert all(seen.values()), full_output
+    return full_output
+
+
+def wait_startup_logs(proc, log_path, label):
+    output = wait_log_contains(
+        log_path,
+        ["Started listening tentacle"],
+        label,
+    )
+    assert proc.poll() is None, output
+    return output
+
+
+def stop_process(proc):
+    if proc.poll() is not None:
+        return
+
+    os.killpg(proc.pid, signal.SIGINT)
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=10)
+
+
+def start_node(install_dir, label):
+    env = os.environ.copy()
+    env["FIBER_SECRET_KEY_PASSWORD"] = "password0"
+    log_path = install_dir / "node.log"
+    log_file = open(log_path, "w")
+    proc = subprocess.Popen(
+        ["bash", str(install_dir / "start-node.sh")],
+        cwd=str(install_dir),
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+        preexec_fn=os.setsid,
+    )
+    proc._fiber_log_file = log_file
+    return proc, log_path, label
+
+
+def close_node_log(proc):
+    log_file = getattr(proc, "_fiber_log_file", None)
+    if log_file:
+        log_file.close()
+
+
+def wait_peer_connected(client, pubkey, timeout=120):
+    for i in range(timeout):
+        peers = client.list_peers().get("peers", [])
+        if any(peer["pubkey"] == pubkey for peer in peers):
+            print(f"Peer {pubkey} connected")
+            return
+        print(f"Waiting for peer {pubkey} to connect, try count: {i}", flush=True)
+        time.sleep(1)
+    raise TimeoutError(f"Peer {pubkey} did not connect")
+
+
+def get_channel_state(client: FiberRPCClient, pubkey: str) -> Tuple[str, Optional[str]]:
+    channels = client.list_channels({"pubkey": pubkey, "include_closed": True})[
+        "channels"
+    ]
+    if not channels:
+        return "not found", None
+    return channels[0]["state"]["state_name"], channels[0].get("channel_id")
+
+
+def get_channel_by_id(client: FiberRPCClient, pubkey: str, channel_id: str):
+    channels = client.list_channels({"pubkey": pubkey, "include_closed": True})[
+        "channels"
+    ]
+    for channel in channels:
+        if channel.get("channel_id") == channel_id:
+            return channel
+    raise AssertionError(f"channel {channel_id} not found")
+
+
+def wait_channel_states(
+    client1: FiberRPCClient,
+    client1_peer_pubkey: str,
+    client2: FiberRPCClient,
+    client2_peer_pubkey: str,
+    expected_state: str,
+    timeout: int = 600,
+) -> str:
+    poll_interval = 2
+    deadline = time.time() + timeout
+    try_count = 0
+
+    while time.time() < deadline:
+        state1, channel_id1 = get_channel_state(client1, client1_peer_pubkey)
+        state2, channel_id2 = get_channel_state(client2, client2_peer_pubkey)
+        print(
+            f"channel1 state: {state1}, channel2 state: {state2}, "
+            f"try count={try_count}",
+            flush=True,
+        )
+        if state1 == expected_state and state2 == expected_state:
+            return channel_id1 or channel_id2 or ""
+        try_count += 1
+        time.sleep(poll_interval)
+    raise TimeoutError(f"channels did not reach {expected_state}")
+
+
+def wait_payment_success(client, payment_hash, timeout=300):
+    for i in range(timeout):
+        payment = client.get_payment({"payment_hash": payment_hash})
+        status = payment["status"]
+        print(
+            f"Waiting for payment {payment_hash}: {status}, try count: {i}", flush=True
+        )
+        if status == "Success":
+            return payment
+        if status == "Failed":
+            raise AssertionError(f"payment failed: {payment}")
+        time.sleep(1)
+    raise TimeoutError("payment did not become Success")
+
+
+def get_ckb_capacity(script, rpc_url=TESTNET_CKB_RPC_URL):
+    response = RPCClient(rpc_url).get_cells_capacity(
+        {"script": script, "script_type": "lock", "script_search_mode": "exact"}
+    )
+    return int(response["capacity"], 16)
+
+
+def wait_committed_transaction(tx_hash, rpc_url=TESTNET_CKB_RPC_URL, timeout=120):
+    client = RPCClient(rpc_url)
+    for i in range(timeout):
+        response = client.get_transaction(tx_hash)
+        if response and response.get("transaction"):
+            status = response.get("tx_status", {}).get("status")
+            if status == "committed":
+                return response["transaction"]
+        print(f"Waiting for committed tx {tx_hash}, try count: {i}", flush=True)
+        time.sleep(1)
+    raise TimeoutError(f"transaction {tx_hash} did not become committed")
+
+
+def get_script_output_capacity_from_tx(tx, lock_script):
+    output_total = 0
+    for output in tx["outputs"]:
+        if output["lock"] == lock_script:
+            output_total += int(output["capacity"], 16)
+    return output_total
+
+
+def format_ckb(shannon):
+    return f"{(Decimal(shannon) / Decimal(CKB)).quantize(Decimal('0.00000001'))} CKB"
+
+
+def print_balance_change(label, before, after):
+    delta = after - before
+    print(
+        f"{label} CKB balance: before={format_ckb(before)}, "
+        f"after={format_ckb(after)}, delta={format_ckb(delta)}"
+    )
+
+
+def first_listen_addr(startup_output):
+    match = re.search(r'(/ip4/127\.0\.0\.1/tcp/\d+/p2p/[^",\s]+)', startup_output)
+    assert match, startup_output
+    return match.group(1)
+
+
+def install_node(script, fnn, tmp_path, name, private_key, p2p_port, rpc_port):
+    fake_bin = tmp_path / f"fake-bin-{name}"
+    make_fake_ckb_cli(fake_bin)
+
+    install_dir = tmp_path / name
+    install_result = run_installer(
+        script, fnn, install_dir, fake_bin, tmp_path, private_key
+    )
+
+    print(install_result.stdout)
+    assert install_result.returncode == 0, install_result.stdout
+    assert "Installation Complete" in install_result.stdout
+    assert "To start your node, run:" in install_result.stdout
+    assert (install_dir / "fnn").exists()
+    assert (install_dir / "fnn-cli").exists()
+    assert (install_dir / "config.yml").exists()
+    assert (install_dir / "start-node.sh").exists()
+
+    key_path = install_dir / "ckb" / "key"
+    assert key_path.read_text().strip() == private_key
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+    patch_config_ports(install_dir / "config.yml", p2p_port, rpc_port)
+    return install_dir
+
+
+@pytest.mark.skipif(os.name != "posix", reason="start-node.sh is a Unix script")
+class TestPR1262InstallScript:
+    def test_install_script_installs_and_starts_node(self, tmp_path):
+        script = install_sh_path()
+        fnn = local_fnn_path()
+        node_p2p_port = free_tcp_port()
+        node_rpc_port = free_tcp_port()
+
+        node_dir = install_node(
+            script,
+            fnn,
+            tmp_path,
+            "node1",
+            ACCOUNT_PRIVATE_1,
+            node_p2p_port,
+            node_rpc_port,
+        )
+
+        node = start_node(node_dir, "node1")
+        node_output = ""
+        try:
+            node_output = wait_startup_logs(*node)
+            client = FiberRPCClient(f"http://127.0.0.1:{node_rpc_port}")
+            node_info = client.node_info()
+            assert "pubkey" in node_info
+            assert "default_funding_lock_script" in node_info
+            listen_addr = first_listen_addr(node_output)
+            assert f"/tcp/{node_p2p_port}/p2p/" in listen_addr
+        finally:
+            stop_process(node[0])
+            close_node_log(node[0])
+
+        assert "Starting Fiber Network Node" in node_output
+        assert "Started listening tentacle" in node_output
+
+    @pytest.mark.skipif(
+        not run_live_channel_test(),
+        reason=(
+            f"set {RUN_LIVE_CHANNEL_ENV}=1 to run the real testnet "
+            "channel/payment/close acceptance flow"
+        ),
+    )
+    def test_install_script_installs_starts_opens_channel_and_sends_payment(
+        self, tmp_path
+    ):
+        """Manual live testnet acceptance flow.
+
+        Run with FIBER_PR1262_RUN_LIVE_CHANNEL=1. This opens a real public
+        testnet channel, sends a keysend payment, and closes the channel.
+        """
+        script = install_sh_path()
+        fnn = local_fnn_path()
+        node1_p2p_port = free_tcp_port()
+        node1_rpc_port = free_tcp_port()
+        node2_p2p_port = free_tcp_port()
+        node2_rpc_port = free_tcp_port()
+
+        node1_dir = install_node(
+            script,
+            fnn,
+            tmp_path,
+            "node1",
+            ACCOUNT_PRIVATE_1,
+            node1_p2p_port,
+            node1_rpc_port,
+        )
+        node2_dir = install_node(
+            script,
+            fnn,
+            tmp_path,
+            "node2",
+            ACCOUNT_PRIVATE_2,
+            node2_p2p_port,
+            node2_rpc_port,
+        )
+
+        node1 = start_node(node1_dir, "node1")
+        node2 = start_node(node2_dir, "node2")
+        processes = [node1[0], node2[0]]
+        node1_output = ""
+        node2_output = ""
+        node1_client = None
+        channel_id = None
+        closed_channel_id = None
+        node1_close_script = None
+        node2_close_script = None
+        try:
+            node1_output = wait_startup_logs(*node1)
+            node2_output = wait_startup_logs(*node2)
+
+            node1_client = FiberRPCClient(f"http://127.0.0.1:{node1_rpc_port}")
+            node2_client = FiberRPCClient(f"http://127.0.0.1:{node2_rpc_port}")
+            node1_info = node1_client.node_info()
+            node2_info = node2_client.node_info()
+            node1_close_script = node1_info["default_funding_lock_script"]
+            node2_close_script = node2_info["default_funding_lock_script"]
+            node2_addr = first_listen_addr(node2_output)
+            node1_balance_before_open = get_ckb_capacity(node1_close_script)
+            node2_balance_before_open = get_ckb_capacity(node2_close_script)
+            print(
+                f"node1 CKB balance before open: {format_ckb(node1_balance_before_open)}"
+            )
+            print(
+                f"node2 CKB balance before open: {format_ckb(node2_balance_before_open)}"
+            )
+
+            print(f"Connecting node1 to node2: {node2_addr}")
+            node1_client.connect_peer({"address": node2_addr})
+            wait_peer_connected(node1_client, node2_info["pubkey"])
+
+            print("Opening real testnet channel1 from node1 to node2")
+            open_result = node1_client.open_channel(
+                {
+                    "pubkey": node2_info["pubkey"],
+                    "funding_amount": hex(200 * CKB),
+                    "public": True,
+                }
+            )
+            assert "temporary_channel_id" in open_result
+            print(
+                f"channel1 temporary_channel_id: {open_result['temporary_channel_id']}"
+            )
+            channel_id = wait_channel_states(
+                node1_client,
+                node2_info["pubkey"],
+                node2_client,
+                node1_info["pubkey"],
+                "ChannelReady",
+            )
+            node2_channel_before_payment = get_channel_by_id(
+                node2_client, node1_info["pubkey"], channel_id
+            )
+            node2_local_before_payment = int(
+                node2_channel_before_payment["local_balance"], 16
+            )
+
+            print(
+                "Sending real keysend payment from node1 to node2: "
+                f"{format_ckb(PAYMENT_AMOUNT_SHANNON)}"
+            )
+            payment = node1_client.send_payment(
+                {
+                    "amount": hex(PAYMENT_AMOUNT_SHANNON),
+                    "target_pubkey": node2_info["pubkey"],
+                    "keysend": True,
+                    "udt_type_script": None,
+                }
+            )
+            payment = wait_payment_success(node1_client, payment["payment_hash"])
+            assert payment["status"] == "Success"
+            node2_channel_after_payment = get_channel_by_id(
+                node2_client, node1_info["pubkey"], channel_id
+            )
+            node2_local_after_payment = int(
+                node2_channel_after_payment["local_balance"], 16
+            )
+            print(
+                "node2 channel balance before shutdown fee: "
+                f"before={format_ckb(node2_local_before_payment)}, "
+                f"after={format_ckb(node2_local_after_payment)}, "
+                f"delta={format_ckb(node2_local_after_payment - node2_local_before_payment)}"
+            )
+            assert node2_local_after_payment == (
+                node2_local_before_payment + PAYMENT_AMOUNT_SHANNON
+            )
+
+            print("channel1 shutdown request")
+            shutdown_result = node1_client.shutdown_channel(
+                {
+                    "channel_id": channel_id,
+                    "close_script": node1_close_script,
+                    "fee_rate": "0x3FC",
+                }
+            )
+            print(f"channel1 shutdown rpc returned: {shutdown_result}")
+            closed_channel_id = wait_channel_states(
+                node1_client,
+                node2_info["pubkey"],
+                node2_client,
+                node1_info["pubkey"],
+                "Closed",
+                timeout=600,
+            )
+            closed_channel = get_channel_by_id(
+                node2_client, node1_info["pubkey"], channel_id
+            )
+            shutdown_tx_hash = closed_channel.get("shutdown_transaction_hash")
+            print(f"channel1 shutdown_transaction_hash: {shutdown_tx_hash}")
+            assert shutdown_tx_hash
+            shutdown_tx = wait_committed_transaction(shutdown_tx_hash)
+            node2_close_tx_output_capacity = get_script_output_capacity_from_tx(
+                shutdown_tx, node2_close_script
+            )
+
+            node1_balance_after_close = get_ckb_capacity(node1_close_script)
+            node2_balance_after_close = get_ckb_capacity(node2_close_script)
+            print_balance_change(
+                "node1", node1_balance_before_open, node1_balance_after_close
+            )
+            print_balance_change(
+                "node2", node2_balance_before_open, node2_balance_after_close
+            )
+            node2_wallet_delta_after_close = (
+                node2_balance_after_close - node2_balance_before_open
+            )
+            node2_close_fee_share = (
+                node2_local_after_payment
+                - node2_local_before_payment
+                - node2_wallet_delta_after_close
+            )
+            print(
+                "node2 close settlement: "
+                f"wallet delta={format_ckb(node2_wallet_delta_after_close)}, "
+                f"close tx output={format_ckb(node2_close_tx_output_capacity)}, "
+                f"inferred close fee share={format_ckb(node2_close_fee_share)}"
+            )
+            assert node2_close_tx_output_capacity > 0
+            channel_id = None
+        finally:
+            if node1_client and channel_id and node1_close_script:
+                try:
+                    print("channel1 cleanup shutdown request")
+                    shutdown_result = node1_client.shutdown_channel(
+                        {
+                            "channel_id": channel_id,
+                            "close_script": node1_close_script,
+                            "fee_rate": "0x3FC",
+                        }
+                    )
+                    print(f"channel1 cleanup shutdown rpc returned: {shutdown_result}")
+                except Exception as err:
+                    print(f"Failed to request shutdown for channel {channel_id}: {err}")
+
+            for proc in processes:
+                stop_process(proc)
+                close_node_log(proc)
+
+        assert "Starting Fiber Network Node" in node1_output
+        assert "Started listening tentacle" in node1_output
+        assert "Starting Fiber Network Node" in node2_output
+        assert "Started listening tentacle" in node2_output
+        assert closed_channel_id

--- a/test_cases/fiber/testnet/test_install_script_options.py
+++ b/test_cases/fiber/testnet/test_install_script_options.py
@@ -1,0 +1,634 @@
+"""PR #1262 installer regression: CLI options, output formatting, and re-install backup."""
+
+import os
+import pty
+import re
+import select
+import shlex
+import subprocess
+import tarfile
+import textwrap
+import time
+
+import pytest
+
+from test_install_script import (
+    ACCOUNT_1,
+    ACCOUNT_PRIVATE_1,
+    account_info_for_private_key,
+    install_sh_path,
+    make_fake_ckb_cli,
+    run_installer,
+    write_executable,
+)
+
+MAINNET_GENESIS_HASH = (
+    "0x92b197aa1fba0f63633922c61c92375c9c074a93e85963554f5499fe1450d0e5"
+)
+TESTNET_GENESIS_HASH = (
+    "0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606"
+)
+
+
+def run_help(script):
+    return subprocess.run(
+        ["bash", str(script), "--help"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+        check=False,
+    )
+
+
+def run_installer_args(script, *args, input_text=""):
+    return subprocess.run(
+        ["bash", str(script), *args],
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+        check=False,
+    )
+
+
+def installer_env(tmp_path, fake_bin, private_key=ACCOUNT_PRIVATE_1):
+    account = account_info_for_private_key(private_key)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(tmp_path / "home"),
+            "STUB_CKB_PRIVATE_KEY": private_key,
+            "STUB_CKB_MAINNET_ADDRESS": account["mainnet_address"],
+            "STUB_CKB_TESTNET_ADDRESS": account["testnet_address"],
+            "STUB_CKB_LOCK_ARG": account["lock_arg"],
+            "STUB_CKB_LOCK_HASH": account["lock_hash"],
+        }
+    )
+    (tmp_path / "home").mkdir(exist_ok=True)
+    return env
+
+
+def minimal_config(network):
+    rpc_url = (
+        "https://mainnet.ckb.dev/"
+        if network == "mainnet"
+        else "https://testnet.ckbapp.dev/"
+    )
+    return textwrap.dedent(f"""
+        fiber:
+          listening_addr: "/ip4/127.0.0.1/tcp/8228"
+          announce_listening_addr: true
+          announced_addrs: []
+          chain: {network}
+
+        rpc:
+          listening_addr: "127.0.0.1:8227"
+
+        ckb:
+          rpc_url: "{rpc_url}"
+
+        services:
+          - fiber
+          - rpc
+          - ckb
+        """).lstrip()
+
+
+def make_fake_local_fnn_bundle(tmp_path):
+    bundle_dir = tmp_path / "local-fnn"
+    bundle_dir.mkdir()
+    write_executable(
+        bundle_dir / "fnn",
+        """
+        #!/bin/sh
+        echo "fake fnn invoked: $*"
+        exit 0
+        """,
+    )
+    write_executable(
+        bundle_dir / "fnn-cli",
+        """
+        #!/bin/sh
+        echo "fake fnn-cli invoked: $*"
+        exit 0
+        """,
+    )
+    write_executable(
+        bundle_dir / "fnn-migrate",
+        """
+        #!/bin/sh
+        echo "fake fnn-migrate invoked: $*"
+        exit 0
+        """,
+    )
+    for network in ("testnet", "mainnet"):
+        config_dir = bundle_dir / "config" / network
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.yml").write_text(minimal_config(network))
+    return bundle_dir / "fnn"
+
+
+def make_fake_release_bundle(tmp_path):
+    source_dir = tmp_path / "fake-release"
+    source_dir.mkdir()
+    local_fnn = make_fake_local_fnn_bundle(source_dir)
+    bundle_path = tmp_path / "fake-fnn-release.tar.gz"
+    with tarfile.open(bundle_path, "w:gz") as archive:
+        archive.add(local_fnn.parent, arcname="fnn-release")
+    return bundle_path
+
+
+def make_fake_curl(fake_bin, response, bundle_path=None):
+    if bundle_path:
+        output_action = f'cp {shlex.quote(str(bundle_path))} "$output"'
+    else:
+        output_action = 'printf \'%s\\n\' "$response" > "$output"'
+
+    write_executable(
+        fake_bin / "curl",
+        f"""
+        #!/bin/sh
+        output=""
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = "-o" ]; then
+            shift
+            output="$1"
+          fi
+          shift
+        done
+
+        response={shlex.quote(response)}
+        if [ -n "$output" ]; then
+          {output_action}
+          exit 0
+        fi
+
+        printf '%s\\n' "$response"
+        """,
+    )
+
+
+def run_installer_pty(script, args, input_text, env, timeout=120):
+    master_fd, slave_fd = pty.openpty()
+    proc = None
+    output = bytearray()
+
+    try:
+        proc = subprocess.Popen(
+            ["bash", str(script), *args],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            env=env,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        slave_fd = None
+        os.write(master_fd, input_text.encode())
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            readable, _, _ = select.select([master_fd], [], [], 0.1)
+            if readable:
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError:
+                    chunk = b""
+                if chunk:
+                    output.extend(chunk)
+
+            if proc.poll() is not None:
+                while True:
+                    readable, _, _ = select.select([master_fd], [], [], 0)
+                    if not readable:
+                        break
+                    try:
+                        chunk = os.read(master_fd, 4096)
+                    except OSError:
+                        break
+                    if not chunk:
+                        break
+                    output.extend(chunk)
+                break
+        else:
+            proc.kill()
+            raise subprocess.TimeoutExpired(proc.args, timeout, output)
+
+        return subprocess.CompletedProcess(
+            proc.args, proc.returncode, output.decode(errors="replace")
+        )
+    finally:
+        if proc and proc.poll() is None:
+            proc.kill()
+        if slave_fd is not None:
+            os.close(slave_fd)
+        os.close(master_fd)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="install.sh is a Unix script")
+class TestPR1262InstallScriptOptions:
+    def test_help_outputs_usage(self):
+        script = install_sh_path()
+        result = run_help(script)
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Fiber Network Node (FNN) installer" in result.stdout
+        assert "Usage:" in result.stdout
+        assert "--local-binary" in result.stdout
+        assert "--mode" in result.stdout
+
+    def test_invalid_network_rejected(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        env = installer_env(tmp_path, fake_bin)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(script),
+                "--local-binary",
+                str(fnn),
+                str(tmp_path / "node"),
+                "foonet",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=60,
+            check=False,
+        )
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "Invalid network" in result.stdout
+        assert "foonet" in result.stdout
+
+    def test_invalid_mode_rejected(self, tmp_path):
+        script = install_sh_path()
+        result = run_installer_args(
+            script, "--mode", "weird", str(tmp_path / "node"), "testnet"
+        )
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "Invalid mode" in result.stdout
+
+    def test_unknown_option_rejected(self, tmp_path):
+        script = install_sh_path()
+        result = run_installer_args(script, "--definitely-not-an-option")
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "Unknown option" in result.stdout
+
+    def test_mode_requires_value(self):
+        script = install_sh_path()
+        result = run_installer_args(script, "--mode")
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "--mode requires a value" in result.stdout
+
+    def test_local_binary_requires_value(self):
+        script = install_sh_path()
+        result = run_installer_args(script, "--local-binary")
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "--local-binary requires a path" in result.stdout
+
+    def test_missing_local_binary_rejected(self, tmp_path):
+        script = install_sh_path()
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        env = installer_env(tmp_path, fake_bin)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(script),
+                "--local-binary",
+                str(tmp_path / "missing-fnn"),
+                str(tmp_path / "node"),
+                "testnet",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=60,
+            check=False,
+        )
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "Local fnn binary not found" in result.stdout
+
+    def test_bootstrap_mode_installs_default_testnet_bundle(self, tmp_path):
+        script = install_sh_path()
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        release_bundle = make_fake_release_bundle(tmp_path)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+            bundle_path=release_bundle,
+        )
+        env = installer_env(tmp_path, fake_bin)
+
+        result = subprocess.run(
+            ["bash", str(script), "--mode", "bootstrap"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+        print(result.stdout)
+        install_dir = tmp_path / "home" / ".fiber"
+        assert result.returncode == 0, result.stdout
+        assert "Running in non-interactive mode with defaults" in result.stdout
+        assert "Network: testnet" in result.stdout
+        assert (install_dir / ".fiber-network").read_text().strip() == "testnet"
+        assert (install_dir / "tools" / "install" / "install.sh").exists()
+        assert (install_dir / "fiber").is_dir()
+        assert (install_dir / "fnn").exists()
+        assert (install_dir / "fnn-cli").exists()
+        assert (install_dir / "fnn-migrate").exists()
+        config = (install_dir / "config.yml").read_text()
+        assert "chain: testnet" in config
+
+    def test_install_output_has_no_literal_ansi_escape(self, tmp_path):
+        """Regression for ANSI literal `\\033[0m` text in formatted sections."""
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        result = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Installation Complete" in result.stdout
+        # The installer must not leak literal escape sequences in its output.
+        assert "\\033[" not in result.stdout, (
+            "literal ANSI escape sequence found in installer output:\n" + result.stdout
+        )
+        assert "\\e[" not in result.stdout
+
+    def test_existing_install_dir_is_backed_up(self, tmp_path):
+        """Re-running the installer on a non-empty dir should back it up
+        (non-interactive path) and produce a fresh install."""
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        first = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        assert first.returncode == 0, first.stdout
+        first_key = (install_dir / "ckb" / "key").read_text().strip()
+
+        second = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        print(second.stdout)
+        assert second.returncode == 0, second.stdout
+        assert "Backed up existing install path" in second.stdout
+
+        backups = sorted(tmp_path.glob("node.backup-*"))
+        assert backups, f"expected backup dir, got: {list(tmp_path.iterdir())}"
+        assert (backups[-1] / "ckb" / "key").exists()
+
+        # Fresh install should still be valid.
+        assert (install_dir / "fnn").exists()
+        assert (install_dir / "start-node.sh").exists()
+        assert (install_dir / "config.yml").exists()
+        assert (install_dir / "ckb" / "key").read_text().strip() == first_key
+
+    def test_existing_install_dir_preserves_ckb_cli_after_backup(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        install_dir = tmp_path / "node"
+        install_dir.mkdir()
+        write_executable(
+            install_dir / "ckb-cli",
+            """
+            #!/bin/sh
+            if [ "$1" = "account" ] && [ "$2" = "list" ]; then
+              cat <<EOF
+            - "#": 0
+              address:
+                mainnet: $STUB_CKB_MAINNET_ADDRESS
+                testnet: $STUB_CKB_TESTNET_ADDRESS
+              lock_arg: $STUB_CKB_LOCK_ARG
+              lock_hash: $STUB_CKB_LOCK_HASH
+              source: Local File System
+            EOF
+              exit 0
+            fi
+
+            if [ "$1" = "account" ] && [ "$2" = "export" ]; then
+              output=""
+              while [ "$#" -gt 0 ]; do
+                if [ "$1" = "--extended-privkey-path" ]; then
+                  shift
+                  output="$1"
+                fi
+                shift
+              done
+              mkdir -p "$(dirname "$output")"
+              printf '%s\\n' "$STUB_CKB_PRIVATE_KEY" > "$output"
+              exit 0
+            fi
+
+            echo "unexpected ckb-cli call: $*" >&2
+            exit 1
+            """,
+        )
+        (install_dir / "old-data").write_text("old")
+
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir()
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        env = installer_env(tmp_path, fake_bin)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(script),
+                "--local-binary",
+                str(fnn),
+                str(install_dir),
+                "testnet",
+            ],
+            input=f"2\n{ACCOUNT_1['lock_arg']}\nn\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Backed up existing install path" in result.stdout
+        assert "Preserved existing ckb-cli" in result.stdout
+        assert (install_dir / "ckb-cli").exists()
+        assert (install_dir / "ckb" / "key").read_text().strip() == ACCOUNT_PRIVATE_1
+
+    def test_generated_start_node_script_uses_install_dir(self, tmp_path):
+        """start-node.sh should resolve INSTALL_DIR relative to itself
+        (so users can re-run it from any cwd after install)."""
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        result = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        assert result.returncode == 0, result.stdout
+
+        start_script = (install_dir / "start-node.sh").read_text()
+        assert 'INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"' in start_script
+        assert "FIBER_SECRET_KEY_PASSWORD" in start_script
+        assert "./fnn -c config.yml" in start_script
+        # Network marker is written/checked so users can't mix networks by mistake.
+        assert ".fiber-network" in start_script
+        # Sanity: no unresolved bash variable from the heredoc escape.
+        assert not re.search(r"\$\{?NETWORK_MARKER_FILE_NAME\}?", start_script)
+
+    def test_generated_start_node_rejects_network_marker_mismatch(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        result = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        assert result.returncode == 0, result.stdout
+        assert (install_dir / ".fiber-network").read_text().strip() == "testnet"
+
+        config_path = install_dir / "config.yml"
+        config_path.write_text(
+            config_path.read_text().replace("chain: testnet", "chain: mainnet")
+        )
+
+        env = os.environ.copy()
+        env["FIBER_SECRET_KEY_PASSWORD"] = "password0"
+        start = subprocess.run(
+            ["bash", str(install_dir / "start-node.sh")],
+            cwd=str(tmp_path),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=30,
+            check=False,
+        )
+        print(start.stdout)
+        assert start.returncode != 0
+        assert "marked for testnet" in start.stdout
+        assert "config.yml is set to mainnet" in start.stdout
+
+    def test_ckb_rpc_preflight_warns_on_wrong_network_genesis(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{MAINNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        result = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Skipping automatic startup" in result.stdout
+        assert "does not appear to be a testnet node" in result.stdout
+        assert "Update ckb.rpc_url" in result.stdout
+
+    def test_mainnet_public_node_configures_announced_fields(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{MAINNET_GENESIS_HASH}"}}',
+        )
+        env = installer_env(tmp_path, fake_bin)
+        install_dir = tmp_path / "node"
+        ckb_rpc_url = "http://127.0.0.1:8114/"
+        announced_addr = "/ip4/203.0.113.10/tcp/8228"
+        announced_name = "Node Name"
+
+        result = run_installer_pty(
+            script,
+            [
+                "--local-binary",
+                str(fnn),
+                str(install_dir),
+                "mainnet",
+            ],
+            (
+                f"{ckb_rpc_url}\n"
+                f"y\n"
+                f"{announced_addr}\n"
+                f"{announced_name}\n"
+                f"2\n"
+                f"{ACCOUNT_1['lock_arg']}\n"
+                f"n\n"
+            ),
+            env,
+        )
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Configured this mainnet node as a public Fiber node" in result.stdout
+
+        config = (install_dir / "config.yml").read_text()
+        assert f'rpc_url: "{ckb_rpc_url}"' in config
+        assert "chain: mainnet" in config
+        assert "auto_announce_node: true" in config
+        assert "announce_listening_addr: true" in config
+        assert f'    - "{announced_addr}"' in config
+        assert f'announced_node_name: "{announced_name}"' in config

--- a/test_cases/fiber/v0.9.0/dlp/test_dlp_backup_restore.py
+++ b/test_cases/fiber/v0.9.0/dlp/test_dlp_backup_restore.py
@@ -1,0 +1,277 @@
+"""Regression suite for fiber PR #1197 — Data Loss Protection (DLP).
+
+PR features:
+  * RPC `info.backup_now()` — manually trigger a backup (no args; backups go
+    under `<fiber_base_dir>/backups/<timestamp_ms>/`).
+  * CLI `fnn --restore <BACKUP_PATH>` — restore from disk and exit, marking
+    every previously-open channel as `ChannelState::Stale`.
+  * `StoreActor` — periodic + event-driven backups; on startup the first
+    deadline is forced ~now so a backup is produced shortly after boot.
+  * `ChannelState::Stale` — passive audit handshake on reestablish.
+
+History note: the initial PR shipped with a "Backup directory already
+exists" sequencing bug that prevented the RocksDB checkpoint from being
+created. The fix landed as commits `de6e38ca` (reorder + per-call timestamp
+subdir) and `d583933e` (drop `target_path` arg from `backup_now`); these
+tests target that final API.
+"""
+
+import os
+import time
+
+import pytest
+
+from framework.basic_fiber import FiberTest
+from framework.util import get_project_root, run_command
+
+
+def _backups_root(fiber) -> str:
+    """The parent directory that holds per-call timestamped backups."""
+    return os.path.join(fiber.tmp_path, "fiber", "backups")
+
+
+def _list_backups(fiber) -> list:
+    root = _backups_root(fiber)
+    if not os.path.isdir(root):
+        return []
+    entries = []
+    for name in os.listdir(root):
+        full = os.path.join(root, name)
+        if os.path.isdir(full):
+            entries.append(full)
+    entries.sort(key=lambda p: os.path.getmtime(p))
+    return entries
+
+
+def _latest_backup(fiber) -> str:
+    entries = _list_backups(fiber)
+    return entries[-1] if entries else ""
+
+
+def _wait_for_backup_with_db(fiber, timeout: int = 60) -> str:
+    """Wait until at least one `<backups>/<ts>/db/` checkpoint exists. Returns
+    that backup path, or empty string on timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for bak in reversed(_list_backups(fiber)):
+            if os.path.isdir(os.path.join(bak, "db")):
+                return bak
+        time.sleep(1)
+    return ""
+
+
+def _trigger_backup_now(fiber) -> str:
+    """Call the `backup_now` RPC (no args) and return the produced backup dir."""
+    before = set(_list_backups(fiber))
+    fiber.get_client().call("backup_now", [])
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        current = set(_list_backups(fiber))
+        new_dirs = current - before
+        for bak in sorted(new_dirs, key=os.path.getmtime, reverse=True):
+            if os.path.isdir(os.path.join(bak, "db")):
+                return bak
+        time.sleep(1)
+    return ""
+
+
+def _run_restore(fiber, backup_path: str) -> None:
+    """Stop fiber, run `fnn --restore <bak>` (which exits when done), restart."""
+    fiber.stop()
+    # Give RocksDB a moment to release file handles before re-opening for restore.
+    time.sleep(2)
+    fnn_bin = f"{get_project_root()}/{fiber.fiber_config_enum.fiber_bin_path}"
+    cmd = (
+        f"FIBER_SECRET_KEY_PASSWORD='password0' "
+        f"RUST_LOG=info,fnn=info "
+        f"{fnn_bin} -c {fiber.fiber_config_path} -d {fiber.tmp_path} "
+        f"--restore {backup_path} 2>&1"
+    )
+    # Use a plain subprocess call so we can surface fnn's output on failure.
+    import subprocess
+
+    completed = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"fnn --restore failed (exit={completed.returncode}):\n"
+            f"{completed.stdout}"
+        )
+    fiber.start()
+
+
+def _wait_state(client, pubkey, expected: str, timeout: int = 90) -> str:
+    """Poll list_channels until first channel reaches `expected` state."""
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        chs = client.list_channels({"pubkey": pubkey, "include_closed": False})[
+            "channels"
+        ]
+        if chs:
+            last = chs[0]["state"]["state_name"]
+            if last == expected:
+                return last
+        time.sleep(2)
+    return last or "<no channel>"
+
+
+@pytest.mark.skip(reason="v0.9.0 fnn binary is not released yet")
+class TestDlpBackupAndRestore(FiberTest):
+    """Regression suite for nervosnetwork/fiber PR #1197."""
+
+    # ---------------------------------------------------------------- backup
+
+    def test_store_actor_backs_up_key_files(self):
+        """The auto-backup wiring must copy `key` and `sk` into the timestamped
+        backup directory shortly after node startup."""
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 100 * 100000000)
+
+        bak = _wait_for_backup_with_db(self.fiber1, timeout=60)
+        assert bak, "no backup produced under <base>/backups/<timestamp>/db"
+        assert os.path.isfile(os.path.join(bak, "key")), f"missing {bak}/key"
+        assert os.path.isfile(os.path.join(bak, "sk")), f"missing {bak}/sk"
+
+    def test_store_actor_creates_rocksdb_checkpoint(self):
+        """Auto-backup should produce a RocksDB checkpoint at
+        `<base>/backups/<timestamp>/db/`."""
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 0)
+        bak = _wait_for_backup_with_db(self.fiber1, timeout=60)
+        assert bak, "no RocksDB checkpoint produced under <base>/backups/<ts>/db"
+        # Sanity-check: a RocksDB checkpoint must have CURRENT + at least one SST or MANIFEST.
+        db_dir = os.path.join(bak, "db")
+        contents = os.listdir(db_dir)
+        assert (
+            "CURRENT" in contents
+        ), f"checkpoint at {db_dir} missing CURRENT: {contents}"
+
+    def test_backup_now_rpc_returns_success(self):
+        """Manual `backup_now` (no args) must return success and produce a
+        new timestamped backup containing key/sk/db."""
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 0)
+        bak = _trigger_backup_now(self.fiber1)
+        assert bak, "backup_now did not produce a new backup directory"
+        assert os.path.isdir(os.path.join(bak, "db"))
+        assert os.path.isfile(os.path.join(bak, "key"))
+        assert os.path.isfile(os.path.join(bak, "sk"))
+
+    def test_backup_now_rpc_is_registered(self):
+        """Sanity check that the RPC is registered (no MethodNotFound) and
+        the node continues serving other RPCs afterwards."""
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 0)
+        # Must not raise MethodNotFound; either succeeds or returns a
+        # backup-domain error.
+        try:
+            self.fiber1.get_client().call("backup_now", [])
+        except Exception as exc:  # noqa: BLE001
+            msg = str(exc).lower()
+            assert "method not found" not in msg, f"backup_now not registered: {exc}"
+        assert self.fiber1.get_client().node_info()["pubkey"]
+
+    # --------------------------------------------------------------- restore
+
+    def test_restore_marks_channel_stale(self):
+        """`fnn --restore <bak>` must mark the previously open channel as
+        `Stale`. By design `is_risk_of_penalty()` returns true for any channel
+        in `ChannelReady` / `ShuttingDown`.
+
+        Per PR #1197 author: when commitment numbers match on both sides, the
+        peer-initiated `ReestablishChannel` immediately audits the channel
+        back to `ChannelReady` — Stale is only stably observable while the
+        peer is offline (no audit handshake in flight). We isolate fiber2
+        across the restore to capture that window."""
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 100 * 100000000)
+
+        bak = _trigger_backup_now(self.fiber1)
+        assert bak, "backup_now did not produce a new backup directory"
+
+        # Cache fiber2's pubkey now — once force_stopped, its RPC is unreachable.
+        fiber2_pubkey = self.fiber2.get_pubkey()
+
+        # Take the peer offline so its reestablish handshake cannot auto-heal
+        # the channel back to ChannelReady immediately after restore.
+        self.fiber2.force_stop()
+        time.sleep(2)
+
+        _run_restore(self.fiber1, bak)
+
+        chs = self.fiber1.get_client().list_channels(
+            {"pubkey": fiber2_pubkey, "include_closed": False}
+        )["channels"]
+        assert len(chs) == 1, f"expected 1 channel after restore, got {chs}"
+        assert (
+            chs[0]["state"]["state_name"] == "Stale"
+        ), f"expected Stale, got {chs[0]['state']}"
+
+        # Bring fiber2 back up so teardown can shut it down cleanly.
+        self.fiber2.start()
+
+    def test_restore_marks_channel_stale_after_payment(self):
+        """Stronger Stale precondition: peer has actually advanced its
+        commitment number via a payment between backup and restore."""
+        self.open_channel(self.fiber1, self.fiber2, 500 * 100000000, 200 * 100000000)
+
+        bak = _trigger_backup_now(self.fiber1)
+        assert bak, "backup_now did not produce a new backup directory"
+
+        payment_hash = self.send_payment(self.fiber1, self.fiber2, 5 * 100000000)
+        self.wait_payment_state(self.fiber1, payment_hash, "Success")
+
+        _run_restore(self.fiber1, bak)
+
+        chs = self.fiber1.get_client().list_channels(
+            {"pubkey": self.fiber2.get_pubkey(), "include_closed": False}
+        )["channels"]
+        assert len(chs) == 1, f"expected 1 channel after restore, got {chs}"
+        assert (
+            chs[0]["state"]["state_name"] == "Stale"
+        ), f"expected Stale, got {chs[0]['state']}"
+
+    def test_restore_then_peer_reestablish_resumes_channel_ready(self):
+        """Design (per PR #1197 author): a Stale node never proactively sends
+        `ReestablishChannel` — that would leak data-loss status and invite a
+        sniping attack. Recovery requires the peer (which still has fresh
+        state) to initiate the handshake. When commitment numbers match on
+        both sides the audit succeeds immediately and the channel transitions
+        back to `ChannelReady`.
+
+        We take fiber2 offline across the restore so we can observe the
+        Stale window, then bring fiber2 back up to trigger the
+        peer-initiated audit and assert recovery."""
+        self.open_channel(self.fiber1, self.fiber2, 200 * 100000000, 100 * 100000000)
+
+        bak = _trigger_backup_now(self.fiber1)
+        assert bak, "backup_now did not produce a new backup directory"
+
+        # Cache fiber2's pubkey now — once force_stopped, its RPC is unreachable.
+        fiber2_pubkey = self.fiber2.get_pubkey()
+
+        # Isolate fiber2 so the post-restore Stale window is observable.
+        self.fiber2.force_stop()
+        time.sleep(2)
+
+        _run_restore(self.fiber1, bak)
+
+        chs = self.fiber1.get_client().list_channels(
+            {"pubkey": fiber2_pubkey, "include_closed": False}
+        )["channels"]
+        assert len(chs) == 1, f"expected 1 channel after restore, got {chs}"
+        assert chs[0]["state"]["state_name"] == "Stale"
+
+        # Bring fiber2 back; on reconnect it initiates ReestablishChannel and
+        # fiber1 audits its Stale channel back to ChannelReady.
+        self.fiber2.start()
+        self.fiber2.connect_peer(self.fiber1)
+
+        final = _wait_state(
+            self.fiber1.get_client(),
+            fiber2_pubkey,
+            "ChannelReady",
+            timeout=120,
+        )
+        assert (
+            final == "ChannelReady"
+        ), f"channel did not resume after peer-initiated audit, final state={final}"
+
+        # Sanity check: payment should now work end-to-end.
+        payment_hash = self.send_payment(self.fiber1, self.fiber2, 5 * 100000000)
+        self.wait_payment_state(self.fiber1, payment_hash, "Success")

--- a/test_cases/fiber/v0.9.0/external_funding/test_external_funding_restart.py
+++ b/test_cases/fiber/v0.9.0/external_funding/test_external_funding_restart.py
@@ -1,0 +1,313 @@
+"""Regression suite for fiber PR #1252.
+
+PR #1252 — *Persist external funding state across restarts*.
+
+Background
+----------
+`open_channel_with_external_funding` returns an unsigned funding transaction
+that the user signs with an external wallet (e.g. JoyID). On the WASM build
+this signing step requires a JoyID redirect that can take an arbitrary amount
+of time and may be interleaved with a process restart. Before this PR, the
+ephemeral state needed to (a) accept the user's signed tx in
+`submit_signed_funding_tx` and (b) drive the rest of the funding handshake
+lived in memory only — so any restart between `open_channel_with_external_funding`
+and `submit_signed_funding_tx`, or between submit and `ChannelReady`, would
+abort the channel.
+
+The PR adds an `ExternalFundingPersistState` field on `ChannelActorData` and
+calls `hydrate_external_funding_runtime()` on reload / reestablish so the
+ephemeral state can be reconstructed. It also introduces
+`move_channel_actor_state(old_id, state)` to handle the channel-id transition
+on the acceptor side mid-flow, plus a migration that appends `0u8` (None) to
+existing entries.
+
+Scenarios covered here (mirroring the upstream Rust e2e tests):
+
+  1. Restart the **initiator** *before* `submit_signed_funding_tx`. After
+     restart the initiator can still submit and the channel reaches
+     `ChannelReady`.
+  2. Restart the **acceptor** *before* `submit_signed_funding_tx`. The
+     initiator submits, both peers reach `ChannelReady`.
+  3. Restart the **initiator** *after* `submit_signed_funding_tx` but before
+     `ChannelReady`. The handshake resumes to `ChannelReady`.
+  4. Restart the **acceptor** *after* `submit_signed_funding_tx` but before
+     `ChannelReady`. The handshake resumes to `ChannelReady`.
+
+The "external funding timeout still applies after restart" scenario from the
+upstream Rust suite is intentionally skipped: the dev_config_3 template does
+not expose `external_funding_timeout_seconds`, and the default (5 min) is
+unreasonable for CI. Re-enable once the template surfaces the option.
+"""
+
+import time
+
+import pytest
+
+from test_cases.fiber.devnet.open_channel_with_external_funding.external_funding_base import (
+    ExternalFundingBase,
+)
+
+# ~500 CKB — comfortably above the default
+# `open_channel_auto_accept_min_ckb_funding_amount` (100 CKB) so the acceptor
+# auto-accepts.
+EXTERNAL_FUNDING_AMOUNT = 500 * 100000000
+
+
+def _submit_signed(fiber, channel_id, signed_tx):
+    return fiber.get_client().call(
+        "submit_signed_funding_tx",
+        [{"channel_id": channel_id, "signed_funding_tx": signed_tx}],
+    )
+
+
+def _list_channels_with_peer(fiber, peer_pubkey, include_closed=False):
+    return fiber.get_client().list_channels(
+        {"pubkey": peer_pubkey, "include_closed": include_closed}
+    )["channels"]
+
+
+def _list_pending_channels_with_peer(fiber, peer_pubkey):
+    return fiber.get_client().list_channels(
+        {"pubkey": peer_pubkey, "only_pending": True}
+    )["channels"]
+
+
+def _is_awaiting_external_funding(channel):
+    state = channel["state"]
+    name = state["state_name"]
+    flags = state.get("state_flags", "")
+    return name == "AwaitingExternalFunding" or (
+        name == "NegotiatingFunding" and "AWAITING_EXTERNAL_FUNDING" in (flags or "")
+    )
+
+
+@pytest.mark.skip(reason="v0.9.0 fnn binary is not released yet")
+class TestExternalFundingRestart(ExternalFundingBase):
+    """Each test method opens a fresh externally-funded channel and exercises
+    a different restart point."""
+
+    __test__ = True
+
+    def _restart(self, fiber):
+        """Stop and re-start a fiber node, then wait for its RPC to come back."""
+        fiber.stop()
+        fiber.start(fnn_log_level=self.fnn_log_level)
+
+    def _mine_some(self, n=4):
+        for _ in range(n):
+            self.Miner.miner_with_version(self.node, "0x0")
+
+    def _wait_state(self, fiber, peer_pubkey, expected, timeout=180):
+        """Wait until `fiber` has at least one channel with `peer_pubkey`
+        whose `state.state_name == expected`. Returns the channel dict.
+        Mines a CKB block on each iteration so funding-tx confirmations can
+        make progress."""
+        deadline = time.time() + timeout
+        last_seen = None
+        while time.time() < deadline:
+            channels = _list_channels_with_peer(
+                fiber, peer_pubkey, include_closed=(expected == "Closed")
+            )
+            for ch in channels:
+                last_seen = ch["state"]["state_name"]
+                if last_seen == expected:
+                    return ch
+            try:
+                self.Miner.miner_with_version(self.node, "0x0")
+            except Exception:
+                pass
+            time.sleep(1)
+        assert False, (
+            f"channel with {peer_pubkey} did not reach {expected!r} in "
+            f"{timeout}s (last seen state: {last_seen!r})"
+        )
+
+    def _get_channel_from_pending(self, fiber, peer_pubkey, channel_id):
+        channels = _list_pending_channels_with_peer(fiber, peer_pubkey)
+        for channel in channels:
+            if channel["channel_id"] == channel_id:
+                return channel
+        return None
+
+    def _assert_awaiting_external_funding(self, fiber, peer_pubkey, channel_id, label):
+        channel = self._get_channel_from_pending(fiber, peer_pubkey, channel_id)
+        assert channel is not None, (
+            f"{label}: channel {channel_id} should appear in "
+            "list_channels(only_pending=true)"
+        )
+        assert _is_awaiting_external_funding(channel), (
+            f"{label}: expected awaiting external funding, got "
+            f"state_name={channel['state']['state_name']!r}, "
+            f"state_flags={channel['state'].get('state_flags', '')!r}"
+        )
+        return channel
+
+    def _wait_pending_closed(self, fiber, peer_pubkey, channel_id, timeout=90):
+        deadline = time.time() + timeout
+        last_state = None
+        while time.time() < deadline:
+            channel = self._get_channel_from_pending(fiber, peer_pubkey, channel_id)
+            if channel is not None:
+                last_state = channel["state"]
+                if channel["state"]["state_name"] == "Closed":
+                    return channel
+            try:
+                self.Miner.miner_with_version(self.node, "0x0")
+            except Exception:
+                pass
+            time.sleep(1)
+        assert False, (
+            f"channel {channel_id} did not appear as Closed in "
+            f"list_channels(only_pending=true) within {timeout}s "
+            f"(last state: {last_state!r})"
+        )
+
+    def _setup_external_open(self):
+        """Returns (channel_id, signed_tx).
+
+        fiber1 = initiator. The funding inputs use a freshly-generated
+        external account's lock script (its private key is signed locally
+        via ckb-cli, not by any dev-only RPC), avoiding the acceptor's
+        "peer uses inputs with our lock script" rejection.
+        fiber2 = acceptor.
+        """
+        # Need some confirmed cells under the external account's lock.
+        self._mine_some()
+
+        context = self._open_external_funding_channel(
+            funding_amount=EXTERNAL_FUNDING_AMOUNT,
+            public=True,
+        )
+        signed_tx = self._sign_external_funding_tx(
+            context["unsigned_funding_tx"], context["external_private_key"]
+        )
+        return context["channel_id"], signed_tx
+
+    # ------------------------------------------------------------------
+    # 1. Restart initiator BEFORE submit_signed_funding_tx
+    # ------------------------------------------------------------------
+    def test_initiator_restart_before_submit_then_channel_ready(self):
+        channel_id, signed_tx = self._setup_external_open()
+
+        self._restart(self.fiber1)
+        self.fiber1.connect_peer(self.fiber2)
+
+        result = _submit_signed(self.fiber1, channel_id, signed_tx)
+        assert result["funding_tx_hash"], "submit returned empty funding_tx_hash"
+
+        ch1 = self._wait_state(self.fiber1, self.fiber2.get_pubkey(), "ChannelReady")
+        ch2 = self._wait_state(self.fiber2, self.fiber1.get_pubkey(), "ChannelReady")
+        assert ch1["state"]["state_name"] == "ChannelReady"
+        assert ch2["state"]["state_name"] == "ChannelReady"
+
+    # ------------------------------------------------------------------
+    # 2. Restart acceptor BEFORE submit_signed_funding_tx
+    # ------------------------------------------------------------------
+    def test_acceptor_restart_before_submit_then_channel_ready(self):
+        channel_id, signed_tx = self._setup_external_open()
+
+        self._restart(self.fiber2)
+        self.fiber1.connect_peer(self.fiber2)
+
+        result = _submit_signed(self.fiber1, channel_id, signed_tx)
+        assert result["funding_tx_hash"], "submit returned empty funding_tx_hash"
+
+        ch1 = self._wait_state(self.fiber1, self.fiber2.get_pubkey(), "ChannelReady")
+        ch2 = self._wait_state(self.fiber2, self.fiber1.get_pubkey(), "ChannelReady")
+        assert ch1["state"]["state_name"] == "ChannelReady"
+        assert ch2["state"]["state_name"] == "ChannelReady"
+
+    # ------------------------------------------------------------------
+    # 3. Restart initiator AFTER submit, before ChannelReady
+    # ------------------------------------------------------------------
+    def test_initiator_restart_after_submit_resumes_to_channel_ready(self):
+        channel_id, signed_tx = self._setup_external_open()
+
+        result = _submit_signed(self.fiber1, channel_id, signed_tx)
+        assert result["funding_tx_hash"]
+
+        # Restart immediately — handshake should be in flight or just kicking off.
+        self._restart(self.fiber1)
+        self.fiber1.connect_peer(self.fiber2)
+
+        ch1 = self._wait_state(
+            self.fiber1, self.fiber2.get_pubkey(), "ChannelReady", timeout=180
+        )
+        ch2 = self._wait_state(
+            self.fiber2, self.fiber1.get_pubkey(), "ChannelReady", timeout=180
+        )
+        assert ch1["state"]["state_name"] == "ChannelReady"
+        assert ch2["state"]["state_name"] == "ChannelReady"
+
+    # ------------------------------------------------------------------
+    # 4. Restart acceptor AFTER submit, before ChannelReady
+    # ------------------------------------------------------------------
+    def test_acceptor_restart_after_submit_resumes_to_channel_ready(self):
+        channel_id, signed_tx = self._setup_external_open()
+
+        result = _submit_signed(self.fiber1, channel_id, signed_tx)
+        assert result["funding_tx_hash"]
+
+        self._restart(self.fiber2)
+        self.fiber1.connect_peer(self.fiber2)
+
+        ch1 = self._wait_state(
+            self.fiber1, self.fiber2.get_pubkey(), "ChannelReady", timeout=180
+        )
+        ch2 = self._wait_state(
+            self.fiber2, self.fiber1.get_pubkey(), "ChannelReady", timeout=180
+        )
+        assert ch1["state"]["state_name"] == "ChannelReady"
+        assert ch2["state"]["state_name"] == "ChannelReady"
+
+    # ------------------------------------------------------------------
+    # 5. External-funding timeout (skipped — default is 5 min, not exposed
+    #    via dev_config_3 template).
+    # ------------------------------------------------------------------
+    # @pytest.mark.skip(
+    #     reason="default external_funding_timeout_seconds is 5 min and the "
+    #     "dev_config_3 template does not expose the override; a local 7-min "
+    #     "run also exposes what looks like a fiber bug: after restart "
+    #     "has_funding_timeout_elapsed() uses a hydrated started_at and the "
+    #     "scheduled CheckFundingTimeout is logged as 'Ignore stale funding "
+    #     "timeout check', so the channel stays in "
+    #     "NegotiatingFunding(AWAITING_EXTERNAL_FUNDING) instead of moving to "
+    #     "Closed(FUNDING_ABORTED)."
+    # )
+    def test_external_funding_timeout_still_applies_after_restart(self):
+        self._restart_fibers_with_config_overrides(
+            fiber1_overrides={"external_funding_timeout_seconds": 30}
+        )
+
+        channel_id, _ = self._setup_external_open()
+
+        self._assert_awaiting_external_funding(
+            self.fiber1,
+            self.fiber2.get_pubkey(),
+            channel_id,
+            "before restart",
+        )
+
+        self._restart(self.fiber1)
+        self.fiber1.connect_peer(self.fiber2)
+
+        self._assert_awaiting_external_funding(
+            self.fiber1,
+            self.fiber2.get_pubkey(),
+            channel_id,
+            "after restart before timeout",
+        )
+
+        # Failed channel openings are surfaced via only_pending=true even after
+        # they transition to Closed(FUNDING_ABORTED).
+        ch = self._wait_pending_closed(
+            self.fiber1, self.fiber2.get_pubkey(), channel_id, timeout=90
+        )
+        assert ch["channel_id"] == channel_id, (
+            f"unexpected channel surfaced as Closed: {ch['channel_id']} "
+            f"(expected {channel_id})"
+        )
+        assert ch["state"]["state_name"] == "Closed"
+        assert (
+            ch["state"].get("state_flags") == "FUNDING_ABORTED"
+        ), f"expected FUNDING_ABORTED, got {ch['state'].get('state_flags')!r}"

--- a/test_cases/fiber/v0.9.0/gossip_policy/test_gossip_policy.py
+++ b/test_cases/fiber/v0.9.0/gossip_policy/test_gossip_policy.py
@@ -1,0 +1,301 @@
+"""Integration tests for fiber PR #1263.
+
+PR #1263 — *Add gossip ban and rate limit policy*.
+
+Background
+----------
+Adds ``FiberConfig.gossip_policy`` (``GossipPolicyConfig``) wiring an inbound
+gossip rate-limiter + ban tracker into the fiber network actor:
+
+* ``ban``: peers accumulate ``score`` on each ``GossipViolation``; once
+  ``score >= threshold`` the peer is disconnected and rejected for the next
+  ``duration_ms``. Peers with at least one active channel are NOT
+  disconnected (only scored).
+* ``inbound_channel_update``: token-bucket rate-limiter keyed by
+  ``(peer, outpoint, direction)`` for ChannelUpdate gossip messages. After
+  ``burst`` updates in ``interval_ms`` the limiter rejects further updates
+  from that key.
+* ``outbound_global`` / ``outbound_peer``: token-bucket rate-limit outbound
+  gossip bytes; overflow goes to ``outbound_delay_queue_capacity``.
+* Deferred ChannelAnnouncement: announcements whose funding tx is not yet
+  visible locally are buffered rather than treated as invalid gossip
+  (no ban).
+
+The ``gossip_policy:`` block is loadable from the config file only — it is
+not exposed via CLI flags or env vars. The dev_config_3 template the
+framework renders does not include it; tests below inject it by patching
+the rendered ``config.yml`` between ``prepare()`` and ``start()``.
+
+What is observable from Python integration tests
+------------------------------------------------
+The Python layer can directly drive:
+* ``open_channel`` / ``update_channel`` (broadcasts a ChannelUpdate).
+* ``graph_channels`` on a peer (shows the latest accepted ChannelUpdate for
+  each direction).
+
+Hence we test:
+1. Default ``gossip_policy`` doesn't break boot.
+2. Custom ``gossip_policy`` block under ``fiber:`` is accepted by the parser.
+3. Inbound ChannelUpdate rate-limit: with a very small ``burst`` override,
+   spamming ``update_channel`` from one peer causes the receiver's graph to
+   stop reflecting later fee rates.
+
+Behaviors that require injecting invalid gossip (ban tracker scoring,
+disconnect on threshold, deferred-announcement path) need internal hooks
+not exposed via JSON-RPC, so they are not covered here.
+"""
+
+import re
+import time
+
+import pytest
+
+from framework.basic_fiber import FiberTest
+from framework.config import DEFAULT_MIN_DEPOSIT_CKB
+
+CHANNEL_CAPACITY = 500 * 100000000  # 500 CKB
+PUBLIC_CHANNEL_OTHER = {"public": True}
+
+
+def _inject_gossip_policy_block(config_path, gossip_policy_yaml):
+    """Insert (or replace) a ``gossip_policy:`` block immediately under the
+    top-level ``fiber:`` key in the rendered ``config.yml``.
+
+    ``gossip_policy_yaml`` is the raw multi-line YAML to splice in, already
+    indented with two leading spaces on each non-empty line, e.g.::
+
+        '  gossip_policy:\\n    inbound_channel_update:\\n      burst: 2\\n      interval_ms: 60000\\n'
+    """
+    with open(config_path) as f:
+        content = f.read()
+
+    # Drop any existing gossip_policy block we may have previously injected,
+    # using a simple block-strip: from "  gossip_policy:" up to (but not
+    # including) the next line whose indentation is 0–1 spaces (i.e. the
+    # next top-level key or blank line that breaks indentation).
+    content = re.sub(
+        r"(?ms)^  gossip_policy:\n(?:    .*\n|      .*\n|        .*\n|\s*\n)+",
+        "",
+        content,
+    )
+
+    if not content.startswith("fiber:\n"):
+        raise AssertionError(
+            f"unexpected config.yml shape, doesn't start with 'fiber:': {content[:80]!r}"
+        )
+
+    content = content.replace("fiber:\n", "fiber:\n" + gossip_policy_yaml, 1)
+    with open(config_path, "w") as f:
+        f.write(content)
+
+
+def _restart_fiber_with_gossip_policy(fiber, gossip_policy_yaml, fnn_log_level):
+    fiber.stop()
+    _inject_gossip_policy_block(fiber.fiber_config_path, gossip_policy_yaml)
+    fiber.start(fnn_log_level=fnn_log_level)
+
+
+def _channel_for_peer(fiber, peer_pubkey):
+    channels = fiber.get_client().list_channels({"pubkey": peer_pubkey})["channels"]
+    assert channels, f"no channel with peer {peer_pubkey}"
+    return channels[0]
+
+
+def _graph_channel(fiber, channel_outpoint):
+    """Find a graph_channels entry by channel_outpoint. Returns None if
+    not yet visible in this node's graph."""
+    resp = fiber.get_client().graph_channels({})
+    for ch in resp.get("channels", []):
+        if ch.get("channel_outpoint") == channel_outpoint:
+            return ch
+    return None
+
+
+def _wait_graph_channel(fiber, channel_outpoint, timeout=30):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = _graph_channel(fiber, channel_outpoint)
+        if last is not None:
+            return last
+        time.sleep(1)
+    raise AssertionError(
+        f"channel {channel_outpoint} not found in {fiber.fiber_config_path}'s graph in {timeout}s"
+    )
+
+
+@pytest.mark.skip(reason="v0.9.0 fnn binary is not released yet")
+class TestGossipPolicy(FiberTest):
+    __test__ = True
+
+    # ------------------------------------------------------------------
+    # 1. Default gossip_policy (no override) — the new field must be
+    #    optional, so an existing-template config should still boot.
+    # ------------------------------------------------------------------
+    def test_node_boots_with_default_gossip_policy(self):
+        # setup_method already brought up fiber1 + fiber2 with the
+        # dev_config_3 template, which doesn't set gossip_policy. If the
+        # binary requires the field, both startups would have failed and
+        # this assertion line wouldn't be reached.
+        info1 = self.fiber1.get_client().node_info()
+        info2 = self.fiber2.get_client().node_info()
+        assert info1["pubkey"], "fiber1 node_info missing pubkey"
+        assert info2["pubkey"], "fiber2 node_info missing pubkey"
+
+    # ------------------------------------------------------------------
+    # 2. Custom gossip_policy block under fiber: — the parser must accept
+    #    the new keys.
+    # ------------------------------------------------------------------
+    def test_node_boots_with_custom_gossip_policy(self):
+        custom = (
+            "  gossip_policy:\n"
+            "    ban:\n"
+            "      threshold: 50\n"
+            "      duration_ms: 1000\n"
+            "    inbound_channel_update:\n"
+            "      interval_ms: 1000\n"
+            "      burst: 3\n"
+            "    outbound_global:\n"
+            "      rate_bytes_per_sec: 1024000\n"
+            "      burst_bytes: 2048000\n"
+            "    outbound_peer:\n"
+            "      rate_bytes_per_sec: 51200\n"
+            "      burst_bytes: 102400\n"
+            "    outbound_delay_queue_capacity: 1024\n"
+        )
+        _restart_fiber_with_gossip_policy(
+            self.fiber1, custom, fnn_log_level=self.fnn_log_level
+        )
+        info = self.fiber1.get_client().node_info()
+        assert info["pubkey"], "fiber1 node_info missing pubkey after restart"
+
+    # ------------------------------------------------------------------
+    # 3. Inbound ChannelUpdate rate-limit: with burst=2 / interval_ms=60s
+    #    on fiber2, send 8 update_channel calls from fiber1 with
+    #    increasing fee rates. The 8th value must NOT propagate to fiber2.
+    # ------------------------------------------------------------------
+    def test_channel_update_throttled_when_burst_exceeded(self):
+        # Restart fiber2 with a tight inbound ChannelUpdate limit so we
+        # can observe drops. burst=2 means only 2 updates per 60s per
+        # (peer, outpoint, direction) tuple are accepted before drops kick
+        # in.
+        gossip_yaml = (
+            "  gossip_policy:\n"
+            "    inbound_channel_update:\n"
+            "      interval_ms: 60000\n"
+            "      burst: 2\n"
+        )
+        _restart_fiber_with_gossip_policy(
+            self.fiber2, gossip_yaml, fnn_log_level=self.fnn_log_level
+        )
+        self.fiber1.connect_peer(self.fiber2)
+
+        # Open a *public* channel — only public channels broadcast
+        # ChannelUpdate via gossip (private ones don't trigger inbound
+        # gossip on the peer).
+        self.open_channel(
+            self.fiber1,
+            self.fiber2,
+            CHANNEL_CAPACITY,
+            0,
+            fiber1_fee=1000,
+            fiber2_fee=1000,
+        )
+
+        channel = _channel_for_peer(self.fiber1, self.fiber2.get_pubkey())
+        channel_id = channel["channel_id"]
+        # Wait until both nodes see the channel in their graph (post
+        # ChannelAnnouncement + initial ChannelUpdates).
+        # The graph_channels entry's channel_outpoint identifies the channel
+        # but we don't have the funding tx hash in list_channels response;
+        # fall back to picking the unique channel in graph.
+
+        # First: poll fiber2 until it has at least one channel in its graph
+        # (which means the burst-limited initial updates went through).
+        deadline = time.time() + 30
+        graph_entry = None
+        while time.time() < deadline:
+            chans = self.fiber2.get_client().graph_channels({}).get("channels", [])
+            if chans:
+                graph_entry = chans[0]
+                break
+            time.sleep(1)
+        assert graph_entry is not None, (
+            "fiber2's graph never saw the new channel — the initial "
+            "ChannelAnnouncement + ChannelUpdate didn't propagate at all"
+        )
+
+        # Now spam 8 update_channel calls from fiber1 with strictly
+        # increasing fee rates. Each call causes fiber1 to broadcast a new
+        # ChannelUpdate. After fiber2 has accepted `burst` of them within
+        # `interval_ms`, subsequent ones must be dropped.
+        sent_fees = [2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000]
+        for fee in sent_fees:
+            self.fiber1.get_client().update_channel(
+                {
+                    "channel_id": channel_id,
+                    "tlc_fee_proportional_millionths": hex(fee),
+                }
+            )
+            # No sleep between calls — we want them within one burst window.
+
+        # Allow time for any updates that *did* get past fiber2's limiter to
+        # be processed and reflected in its graph.
+        time.sleep(8)
+
+        # Re-fetch fiber2's view. The latest fee rate seen on fiber1's
+        # direction in fiber2's graph must be strictly less than the
+        # newest sent value (9000) — otherwise the rate-limit isn't
+        # working.
+        chans = self.fiber2.get_client().graph_channels({}).get("channels", [])
+        assert chans, "fiber2 lost the channel from its graph after updates"
+
+        ours = None
+        outpoint = graph_entry.get("channel_outpoint")
+        for c in chans:
+            if c.get("channel_outpoint") == outpoint:
+                ours = c
+                break
+        assert ours is not None, f"fiber2's graph no longer contains channel {outpoint}"
+
+        # graph_channels response shape (observed):
+        #   {"node1": "<pubkey>", "node2": "<pubkey>",
+        #    "update_info_of_node1": {"fee_rate": "0x..", "enabled": .., ...},
+        #    "update_info_of_node2": {...}, ...}
+        # The direction whose top-level node pubkey matches fiber1's pubkey
+        # is the one being rate-limited.
+        fiber1_pubkey = self.fiber1.get_pubkey()
+
+        def _direction_fee(entry, pubkey):
+            if entry.get("node1") == pubkey:
+                upd = entry.get("update_info_of_node1")
+            elif entry.get("node2") == pubkey:
+                upd = entry.get("update_info_of_node2")
+            else:
+                return None
+            if upd is None:
+                return None
+            return int(upd.get("fee_rate", "0x0"), 16)
+
+        fiber1_direction_fee = _direction_fee(ours, fiber1_pubkey)
+        assert (
+            fiber1_direction_fee is not None
+        ), f"could not locate fiber1's direction in graph entry: {ours!r}"
+
+        max_sent = sent_fees[-1]
+        # Rate-limited: fiber2 must NOT have absorbed the very last update.
+        assert fiber1_direction_fee < max_sent, (
+            f"fiber2 absorbed the latest update fee={fiber1_direction_fee} "
+            f"(latest sent={max_sent}); rate-limit appears not to be in effect"
+        )
+        # Sanity: fiber1's own graph (it bypasses inbound limiter) DOES
+        # reflect the latest.
+        own_chans = self.fiber1.get_client().graph_channels({}).get("channels", [])
+        own = next(
+            (c for c in own_chans if c.get("channel_outpoint") == outpoint), None
+        )
+        assert own is not None, "fiber1 lost the channel from its own graph"
+        own_fee = _direction_fee(own, fiber1_pubkey)
+        assert (
+            own_fee == max_sent
+        ), f"fiber1's own graph fee={own_fee} != latest sent {max_sent}"

--- a/test_cases/fiber/v0.9.0/preimage_retention/test_mpp_force_close_preimage.py
+++ b/test_cases/fiber/v0.9.0/preimage_retention/test_mpp_force_close_preimage.py
@@ -1,0 +1,444 @@
+"""Regression test for fiber PR #1335.
+
+PR #1335 — *Fix preimage retention for MPP during force-close scenarios*
+(fixes issue https://github.com/nervosnetwork/fiber/issues/1332).
+
+Background
+----------
+For an MPP payment that splits across two parallel *upstream* channels of a
+forwarding node, the forwarding node used to drop the payment preimage as
+soon as the **online** split was fulfilled off-chain.  If the **other**
+upstream channel had been force-closed in the meantime, its received-HTLC
+output on-chain could no longer be claimed (the watchtower / on-chain
+settlement path needs the preimage), so the forwarding node would lose the
+forwarded funds and the on-chain settlement would stall.
+
+The PR keeps the preimage as long as another TLC with the same
+`payment_hash` is still pending on-chain settlement
+(``has_onchain_tlc_for_payment_hash``).
+
+Topology
+--------
+::
+
+    fiber1 (sender)  ==[ chA ]==  fiber2 (mid)  ==[ chC ]==  fiber3 (receiver)
+                     ==[ chB ]==
+
+The Python integration test cannot read the preimage store directly, so it
+asserts the observable consequences of the fix:
+
+1. Both partial TLCs reach fiber3 (invoice goes to ``Received``).
+2. fiber2 force-closes the first upstream channel (chA) while both TLCs
+   are still in-flight.
+3. fiber3 settles the invoice.
+4. The **online** split is fulfilled off-chain — the corresponding inbound
+   TLC on fiber2's chB and outbound TLC on fiber1's chB disappear.
+5. The **force-closed** split's inbound TLC on fiber2's chA must remain
+   pending (waiting for on-chain settlement).  This proves the new
+   retention path is on: with the old code, the preimage would have been
+   dropped together with the online split, and the on-chain TLC could
+   never be claimed.
+"""
+
+import hashlib
+import time
+
+import pytest
+
+from framework.basic_fiber import FiberTest
+
+
+def _sha256_hex(preimage_hex: str) -> str:
+    raw = bytes.fromhex(preimage_hex.replace("0x", ""))
+    return "0x" + hashlib.sha256(raw).hexdigest()
+
+
+# Channel capacities (in shannons). Each upstream channel can carry less
+# than the invoice amount on its own, forcing the MPP router to split.
+UPSTREAM_CAPACITY = 500 * 100000000
+DOWNSTREAM_CAPACITY = 2000 * 100000000
+INVOICE_AMOUNT = 600 * 100000000
+
+
+@pytest.mark.skip(reason="v0.9.0 fnn binary is not released yet")
+class TestPR1335MppForceClosePreimageRetention(FiberTest):
+
+    start_fiber_config = {"fiber_watchtower_check_interval_seconds": 5}
+
+    def _list_channels_by_peer(self, fiber, peer_fiber):
+        return fiber.get_client().list_channels(
+            {"pubkey": peer_fiber.get_pubkey(), "include_closed": True}
+        )["channels"]
+
+    def _pending_payment_hashes(self, channel):
+        return [tlc["payment_hash"] for tlc in channel.get("pending_tlcs", [])]
+
+    def test_preimage_retained_for_onchain_split(self):
+        # --- Topology -----------------------------------------------------
+        fiber3 = self.start_new_fiber(
+            self.generate_account(10000, self.fiber1.account_private, 0)
+        )
+        # Two parallel upstream channels fiber1 -> fiber2.
+        self.open_channel(self.fiber1, self.fiber2, UPSTREAM_CAPACITY, 0, 0, 0)
+        self.open_channel(self.fiber1, self.fiber2, UPSTREAM_CAPACITY, 0, 0, 0)
+        # Single downstream channel fiber2 -> fiber3 with enough room for
+        # both forwarded splits.
+        self.open_channel(self.fiber2, fiber3, DOWNSTREAM_CAPACITY, 0, 0, 0)
+
+        # Wait for graph sync so the sender sees all three channels.
+        self.wait_graph_channels_sync(self.fiber1, 3, timeout=120)
+
+        upstream_channels = self._list_channels_by_peer(self.fiber2, self.fiber1)
+        assert (
+            len(upstream_channels) == 2
+        ), f"expected 2 parallel upstream channels, got {len(upstream_channels)}"
+        channel_a_id = upstream_channels[0]["channel_id"]
+        channel_b_id = upstream_channels[1]["channel_id"]
+
+        # --- Hold MPP invoice on the receiver -----------------------------
+        preimage = self.generate_random_preimage()
+        payment_hash = _sha256_hex(preimage)
+        invoice = fiber3.get_client().new_invoice(
+            {
+                "amount": hex(INVOICE_AMOUNT),
+                "currency": "Fibd",
+                "description": "PR-1335 MPP force-close hold invoice",
+                "payment_hash": payment_hash,
+                "hash_algorithm": "sha256",
+                "expiry": "0xe10",
+                "final_cltv": "0x28",
+                "allow_mpp": True,
+            }
+        )
+
+        # --- Send the MPP payment -----------------------------------------
+        payment = self.fiber1.get_client().send_payment(
+            {
+                "invoice": invoice["invoice_address"],
+                "max_parts": hex(2),
+                "max_fee_rate": hex(1000000000000000),
+            }
+        )
+        assert payment["payment_hash"] == payment_hash
+
+        # Wait until both partial TLCs land on fiber3 (invoice = Received).
+        self.wait_invoice_state(fiber3, payment_hash, "Received", timeout=120)
+
+        # Sanity: fiber2 must be forwarding two inbound TLCs (one per
+        # upstream channel) for this payment_hash.
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            upstream_channels = self._list_channels_by_peer(self.fiber2, self.fiber1)
+            inbound_per_channel = {
+                ch["channel_id"]: self._pending_payment_hashes(ch).count(payment_hash)
+                for ch in upstream_channels
+            }
+            if (
+                inbound_per_channel.get(channel_a_id, 0) >= 1
+                and inbound_per_channel.get(channel_b_id, 0) >= 1
+            ):
+                break
+            time.sleep(1)
+        else:
+            assert False, (
+                "fiber2 did not receive one inbound TLC per upstream "
+                f"channel: {inbound_per_channel}"
+            )
+
+        # --- Force-close channel A (one of the upstream channels) ---------
+        self.fiber2.get_client().shutdown_channel(
+            {"channel_id": channel_a_id, "force": True}
+        )
+        force_tx = self.wait_and_check_tx_pool_fee(1000, False)
+        self.Miner.miner_until_tx_committed(self.node, force_tx)
+        # A few extra blocks so the close is fully observed by the node.
+        self.node.getClient().generate_epochs("0x1", wait_time=0)
+
+        # Confirm channel A is closed while channel B is still ChannelReady.
+        for _ in range(30):
+            upstream_channels = self._list_channels_by_peer(self.fiber2, self.fiber1)
+            by_id = {ch["channel_id"]: ch for ch in upstream_channels}
+            state_a = by_id[channel_a_id]["state"]["state_name"]
+            state_b = by_id[channel_b_id]["state"]["state_name"]
+            if state_a == "Closed" and state_b == "ChannelReady":
+                break
+            time.sleep(1)
+        else:
+            assert False, f"channel states unexpected: A={state_a}, B={state_b}"
+
+        # --- Settle the invoice on the receiver ---------------------------
+        fiber3.get_client().settle_invoice(
+            {"payment_hash": payment_hash, "payment_preimage": preimage}
+        )
+
+        # The online split must be fulfilled off-chain: channel B's inbound
+        # TLC on fiber2 (and the corresponding outbound on fiber1) goes
+        # away. The force-closed split's inbound TLC on channel A must
+        # remain pending until on-chain settlement completes.
+        deadline = time.time() + 60
+        chan_a = chan_b = None
+        while time.time() < deadline:
+            upstream_channels = self._list_channels_by_peer(self.fiber2, self.fiber1)
+            by_id = {ch["channel_id"]: ch for ch in upstream_channels}
+            chan_a = by_id.get(channel_a_id)
+            chan_b = by_id.get(channel_b_id)
+            online_cleared = (
+                chan_b is not None
+                and self._pending_payment_hashes(chan_b).count(payment_hash) == 0
+            )
+            onchain_pending = (
+                chan_a is not None
+                and self._pending_payment_hashes(chan_a).count(payment_hash) >= 1
+            )
+            if online_cleared and onchain_pending:
+                break
+            time.sleep(1)
+        else:
+            assert False, (
+                "after settle: expected online split cleared and on-chain "
+                f"split still pending; chan_a.pending_tlcs="
+                f"{chan_a and chan_a.get('pending_tlcs')}, "
+                f"chan_b.pending_tlcs="
+                f"{chan_b and chan_b.get('pending_tlcs')}"
+            )
+
+        # Receiver's invoice should be Paid once the off-chain settle event
+        # is processed (this also implicitly checks the preimage was
+        # accepted and the invoice store committed it).
+        self.wait_invoice_state(fiber3, payment_hash, "Paid", timeout=60)
+
+        # Mid-assertion (PR-1335 core, off-chain side): the force-closed
+        # channel still carries the inbound TLC for `payment_hash`. With
+        # the old code, the preimage would already have been removed
+        # together with the online split — leaving the on-chain TLC
+        # unclaimable.
+        chan_a_mid = {
+            ch["channel_id"]: ch
+            for ch in self._list_channels_by_peer(self.fiber2, self.fiber1)
+        }[channel_a_id]
+        on_chain_tlcs = [
+            tlc
+            for tlc in chan_a_mid.get("pending_tlcs", [])
+            if tlc["payment_hash"] == payment_hash
+        ]
+        assert len(on_chain_tlcs) >= 1, (
+            "force-closed channel must retain its inbound TLC pending "
+            "on-chain settlement; pending_tlcs="
+            f"{chan_a_mid.get('pending_tlcs')}"
+        )
+        split_amount_on_a = int(on_chain_tlcs[0]["amount"], 16)
+
+        # --- On-chain verification ---------------------------------------
+        # The real proof of PR-1335: fiber2's watchtower must use the
+        # *retained* preimage to spend the received-HTLC output of the
+        # force-closed commitment tx. Mine ~600 blocks (one delay epoch
+        # window used by the existing watchtower tests) so the watchtower
+        # check interval triggers a settle tx on-chain.
+        for _ in range(600):
+            self.Miner.miner_with_version(self.node, "0x0")
+
+        deadline = time.time() + 60
+        tx_trace = []
+        while time.time() < deadline:
+            tx_trace = self.get_ln_tx_trace(force_tx)
+            # tx_trace[0] = the force-close commitment tx itself
+            # tx_trace[1] = the watchtower preimage-unlock settle tx
+            if len(tx_trace) >= 2:
+                break
+            for _ in range(30):
+                self.Miner.miner_with_version(self.node, "0x0")
+            time.sleep(2)
+        assert len(tx_trace) >= 2, (
+            "watchtower did not spend the on-chain received-HTLC cell "
+            "using the retained preimage; only saw force-close tx. "
+            "tx_trace="
+            f"{[t['tx_hash'] for t in tx_trace]}"
+        )
+
+        # The preimage-unlock tx must consume capacity equal to the TLC
+        # amount that landed on channel A (modulo tx fee, sub-CKB).
+        settle_msg = tx_trace[1]["msg"]
+        capacity_diff = (
+            settle_msg["input_cells"][0]["capacity"]
+            - settle_msg["output_cells"][0]["capacity"]
+        )
+        assert abs(capacity_diff - split_amount_on_a) < 100000000, (
+            f"settle tx capacity diff {capacity_diff} does not match "
+            f"on-chain split amount {split_amount_on_a}"
+        )
+        # Reaching this point proves PR-1335: fiber2 still held the
+        # preimage after the online split was fulfilled, and used it to
+        # produce the on-chain settle tx for the force-closed split.
+
+    def test_preimage_retained_when_settle_before_channel_closed(self):
+        """Variant of the above: settle the invoice **immediately after
+        the force-close commitment tx is confirmed on-chain**, without
+        waiting for fiber2's channel A to transition to ``Closed``.
+
+        Motivation (from PR-1335 discussion): in the original repro the
+        forwarding node could already drop the preimage if the *online*
+        split was fulfilled while channel A was still mid-shutdown (i.e.
+        before its state machine fully reached ``Closed``). This test
+        pins down that timing — settle is invoked as soon as the
+        shutdown tx lands in the tx pool / one block confirmation — and
+        asserts the same observable consequences of the fix as the main
+        test (online split off-chain cleared, force-closed split
+        retained, invoice → Paid, watchtower settles on-chain with the
+        retained preimage).
+        """
+
+        # --- Topology -----------------------------------------------------
+        fiber3 = self.start_new_fiber(
+            self.generate_account(10000, self.fiber1.account_private, 0)
+        )
+        self.open_channel(self.fiber1, self.fiber2, UPSTREAM_CAPACITY, 0, 0, 0)
+        self.open_channel(self.fiber1, self.fiber2, UPSTREAM_CAPACITY, 0, 0, 0)
+        self.open_channel(self.fiber2, fiber3, DOWNSTREAM_CAPACITY, 0, 0, 0)
+        self.wait_graph_channels_sync(self.fiber1, 3, timeout=120)
+
+        upstream_channels = self._list_channels_by_peer(self.fiber2, self.fiber1)
+        assert (
+            len(upstream_channels) == 2
+        ), f"expected 2 parallel upstream channels, got {len(upstream_channels)}"
+        channel_a_id = upstream_channels[0]["channel_id"]
+        channel_b_id = upstream_channels[1]["channel_id"]
+
+        # --- Hold MPP invoice on the receiver -----------------------------
+        preimage = self.generate_random_preimage()
+        payment_hash = _sha256_hex(preimage)
+        invoice = fiber3.get_client().new_invoice(
+            {
+                "amount": hex(INVOICE_AMOUNT),
+                "currency": "Fibd",
+                "description": "PR-1335 settle-before-closed hold invoice",
+                "payment_hash": payment_hash,
+                "hash_algorithm": "sha256",
+                "expiry": "0xe10",
+                "final_cltv": "0x28",
+                "allow_mpp": True,
+            }
+        )
+
+        # --- Send the MPP payment -----------------------------------------
+        payment = self.fiber1.get_client().send_payment(
+            {
+                "invoice": invoice["invoice_address"],
+                "max_parts": hex(2),
+                "max_fee_rate": hex(1000000000000000),
+            }
+        )
+        assert payment["payment_hash"] == payment_hash
+        self.wait_invoice_state(fiber3, payment_hash, "Received", timeout=120)
+
+        # Sanity: one inbound TLC per upstream channel on fiber2.
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            upstream_channels = self._list_channels_by_peer(self.fiber2, self.fiber1)
+            inbound_per_channel = {
+                ch["channel_id"]: self._pending_payment_hashes(ch).count(payment_hash)
+                for ch in upstream_channels
+            }
+            if (
+                inbound_per_channel.get(channel_a_id, 0) >= 1
+                and inbound_per_channel.get(channel_b_id, 0) >= 1
+            ):
+                break
+            time.sleep(1)
+        else:
+            assert False, (
+                "fiber2 did not receive one inbound TLC per upstream "
+                f"channel: {inbound_per_channel}"
+            )
+
+        # --- Force-close channel A and settle immediately after the
+        # commitment tx is confirmed on-chain (do NOT wait for state =
+        # Closed). This is the timing variation PR-1335 must also cover.
+        self.fiber2.get_client().shutdown_channel(
+            {"channel_id": channel_a_id, "force": True}
+        )
+        force_tx = self.wait_and_check_tx_pool_fee(1000, False)
+        self.Miner.miner_until_tx_committed(self.node, force_tx)
+
+        # Settle immediately — channel A is still in the shutdown flow,
+        # NOT yet Closed. With the buggy version, fulfilling the online
+        # split here would also evict the preimage even though channel
+        # A's HTLC is now on-chain only.
+        fiber3.get_client().settle_invoice(
+            {"payment_hash": payment_hash, "payment_preimage": preimage}
+        )
+
+        # Off-chain: online split (chB) clears; on-chain split (chA)
+        # retained.
+        deadline = time.time() + 60
+        chan_a = chan_b = None
+        while time.time() < deadline:
+            upstream_channels = self._list_channels_by_peer(self.fiber2, self.fiber1)
+            by_id = {ch["channel_id"]: ch for ch in upstream_channels}
+            chan_a = by_id.get(channel_a_id)
+            chan_b = by_id.get(channel_b_id)
+            online_cleared = (
+                chan_b is not None
+                and self._pending_payment_hashes(chan_b).count(payment_hash) == 0
+            )
+            onchain_pending = (
+                chan_a is not None
+                and self._pending_payment_hashes(chan_a).count(payment_hash) >= 1
+            )
+            if online_cleared and onchain_pending:
+                break
+            time.sleep(1)
+        else:
+            assert False, (
+                "after settle-before-closed: expected online split cleared "
+                "and on-chain split still pending; "
+                f"chan_a.pending_tlcs={chan_a and chan_a.get('pending_tlcs')}, "
+                f"chan_b.pending_tlcs={chan_b and chan_b.get('pending_tlcs')}"
+            )
+
+        self.wait_invoice_state(fiber3, payment_hash, "Paid", timeout=60)
+
+        chan_a_mid = {
+            ch["channel_id"]: ch
+            for ch in self._list_channels_by_peer(self.fiber2, self.fiber1)
+        }[channel_a_id]
+        on_chain_tlcs = [
+            tlc
+            for tlc in chan_a_mid.get("pending_tlcs", [])
+            if tlc["payment_hash"] == payment_hash
+        ]
+        assert len(on_chain_tlcs) >= 1, (
+            "force-closed channel must retain its inbound TLC pending "
+            "on-chain settlement even when settle was issued before "
+            "channel reached Closed; pending_tlcs="
+            f"{chan_a_mid.get('pending_tlcs')}"
+        )
+        split_amount_on_a = int(on_chain_tlcs[0]["amount"], 16)
+
+        # --- On-chain verification: same as the main case ----------------
+        for _ in range(600):
+            self.Miner.miner_with_version(self.node, "0x0")
+
+        deadline = time.time() + 60
+        tx_trace = []
+        while time.time() < deadline:
+            tx_trace = self.get_ln_tx_trace(force_tx)
+            if len(tx_trace) >= 2:
+                break
+            for _ in range(30):
+                self.Miner.miner_with_version(self.node, "0x0")
+            time.sleep(2)
+        assert len(tx_trace) >= 2, (
+            "watchtower did not spend the on-chain received-HTLC cell "
+            "using the retained preimage (settle-before-closed timing); "
+            f"tx_trace={[t['tx_hash'] for t in tx_trace]}"
+        )
+
+        settle_msg = tx_trace[1]["msg"]
+        capacity_diff = (
+            settle_msg["input_cells"][0]["capacity"]
+            - settle_msg["output_cells"][0]["capacity"]
+        )
+        assert abs(capacity_diff - split_amount_on_a) < 100000000, (
+            f"settle tx capacity diff {capacity_diff} does not match "
+            f"on-chain split amount {split_amount_on_a}"
+        )

--- a/test_cases/fiber/v0.9.0/preimage_retention/test_mpp_multi_channel_same_payment_hash.py
+++ b/test_cases/fiber/v0.9.0/preimage_retention/test_mpp_multi_channel_same_payment_hash.py
@@ -1,0 +1,251 @@
+"""Regression test for fiber PR #1335 — scenario F.1.
+
+Multi-channel same-payment_hash mixed state:
+- Two parallel channels fiber1 <-> fiber2, one channel fiber2 -> fiber3.
+- MPP payment splits across both fiber1 <-> fiber2 channels.
+- fiber1 force-closes one of the upstream channels while both TLCs are
+  still in flight.
+- fiber3 settles the invoice off-chain.
+
+Expected:
+- The surviving channel's TLC is fulfilled off-chain (preimage propagates
+  back to fiber1).
+- The force-closed channel's on-chain received-HTLC output is later
+  spent by fiber2's watchtower using the *retained* preimage (the PR-1335
+  fix). Without the fix, fiber2 would have dropped the preimage after the
+  off-chain split was fulfilled and the on-chain cell would stay locked.
+"""
+
+import time
+
+import pytest
+
+from framework.basic_fiber import FiberTest
+from framework.util import ckb_hash
+
+UPSTREAM_CAPACITY = 1000 * 100000000
+DOWNSTREAM_CAPACITY = 3000 * 100000000
+INVOICE_AMOUNT = 1500 * 100000000
+
+
+@pytest.mark.skip(reason="v0.9.0 fnn binary is not released yet")
+class TestMppMultiChannelSamePaymentHash(FiberTest):
+
+    start_fiber_config = {"fiber_watchtower_check_interval_seconds": 5}
+
+    def _channels_by_peer(self, fiber, peer_fiber):
+        return fiber.get_client().list_channels(
+            {"pubkey": peer_fiber.get_pubkey(), "include_closed": True}
+        )["channels"]
+
+    def _pending_hashes(self, channel):
+        return [tlc["payment_hash"] for tlc in channel.get("pending_tlcs", [])]
+
+    def test_mpp_with_same_payment_hash(self):
+        # --- Topology -----------------------------------------------------
+        fiber3 = self.start_new_fiber(self.generate_account(10000))
+        self.open_channel(self.fiber1, self.fiber2, UPSTREAM_CAPACITY, 0, 0, 0)
+        self.open_channel(self.fiber1, self.fiber2, UPSTREAM_CAPACITY, 0, 0, 0)
+        self.open_channel(self.fiber2, fiber3, DOWNSTREAM_CAPACITY, 0, 0, 0)
+        self.wait_graph_channels_sync(self.fiber1, 3, timeout=120)
+
+        upstream = self._channels_by_peer(self.fiber1, self.fiber2)
+        assert len(upstream) == 2, f"expected 2 upstream channels, got {len(upstream)}"
+        force_closed_channel = upstream[0]["channel_id"]
+        offchain_channel = upstream[1]["channel_id"]
+
+        # --- Hold MPP invoice on the receiver -----------------------------
+        preimage = self.generate_random_preimage()
+        payment_hash = ckb_hash(preimage)
+        invoice = fiber3.get_client().new_invoice(
+            {
+                "amount": hex(INVOICE_AMOUNT),
+                "currency": "Fibd",
+                "description": "PR-1335 multi-channel same-hash MPP",
+                "payment_hash": payment_hash,
+                "hash_algorithm": "ckb_hash",
+                "expiry": "0xe10",
+                "final_cltv": "0x28",
+                "allow_mpp": True,
+            }
+        )
+
+        # --- Send the MPP payment -----------------------------------------
+        payment = self.fiber1.get_client().send_payment(
+            {
+                "invoice": invoice["invoice_address"],
+                "max_parts": hex(2),
+                "max_fee_rate": hex(1000000000000000),
+            }
+        )
+        assert payment["payment_hash"] == payment_hash
+        self.wait_invoice_state(fiber3, payment_hash, "Received", timeout=120)
+
+        # Sanity: both upstream channels carry one outbound TLC each.
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            chans = {
+                ch["channel_id"]: ch
+                for ch in self._channels_by_peer(self.fiber1, self.fiber2)
+            }
+            if (
+                self._pending_hashes(chans[force_closed_channel]).count(payment_hash)
+                >= 1
+                and self._pending_hashes(chans[offchain_channel]).count(payment_hash)
+                >= 1
+            ):
+                break
+            time.sleep(1)
+        else:
+            assert False, (
+                "expected one outbound TLC per upstream channel; got "
+                f"{{cid: ch['pending_tlcs'] for cid, ch in chans.items()}}"
+            )
+
+        # --- Force-close one of the upstream channels --------------------
+        self.fiber1.get_client().shutdown_channel(
+            {"channel_id": force_closed_channel, "force": True}
+        )
+        force_tx = self.wait_and_check_tx_pool_fee(1000, False)
+        self.Miner.miner_until_tx_committed(self.node, force_tx)
+        self.node.getClient().generate_epochs("0x1", wait_time=0)
+
+        # Wait until the closed channel reports Closed and the other one
+        # stays ChannelReady.
+        for _ in range(30):
+            chans = {
+                ch["channel_id"]: ch
+                for ch in self._channels_by_peer(self.fiber1, self.fiber2)
+            }
+            state_closed = chans[force_closed_channel]["state"]["state_name"]
+            state_alive = chans[offchain_channel]["state"]["state_name"]
+            if state_closed == "Closed" and state_alive == "ChannelReady":
+                break
+            time.sleep(1)
+        else:
+            assert (
+                False
+            ), f"unexpected states: closed={state_closed}, alive={state_alive}"
+
+        # --- Settle invoice on receiver ----------------------------------
+        fiber3.get_client().settle_invoice(
+            {"payment_hash": payment_hash, "payment_preimage": preimage}
+        )
+
+        # Off-chain split clears on the surviving channel; on the
+        # force-closed channel's mirror entry on fiber2 the TLC remains
+        # pending (PR-1335 keeps the preimage so it can be used on-chain).
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            chans_fiber2 = {
+                ch["channel_id"]: ch
+                for ch in self._channels_by_peer(self.fiber2, self.fiber1)
+            }
+            offchain_cleared = (
+                self._pending_hashes(chans_fiber2[offchain_channel]).count(payment_hash)
+                == 0
+            )
+            onchain_still_pending = (
+                self._pending_hashes(chans_fiber2[force_closed_channel]).count(
+                    payment_hash
+                )
+                >= 1
+            )
+            if offchain_cleared and onchain_still_pending:
+                break
+            time.sleep(1)
+        else:
+            assert False, (
+                "after settle: expected off-chain split cleared and "
+                "force-closed split still pending on fiber2; got "
+                f"{ {cid: ch['pending_tlcs'] for cid, ch in chans_fiber2.items()} }"
+            )
+
+        self.wait_invoice_state(fiber3, payment_hash, "Paid", timeout=60)
+
+        # Record the on-chain split amount for the capacity-diff check.
+        onchain_tlc = next(
+            tlc
+            for tlc in chans_fiber2[force_closed_channel]["pending_tlcs"]
+            if tlc["payment_hash"] == payment_hash
+        )
+        split_amount = int(onchain_tlc["amount"], 16)
+
+        # --- On-chain watchtower-settle verification ---------------------
+        # `get_ln_tx_trace` only follows outputs[0] (the to-local
+        # timelock cell). When the sender force-closes, the offered-HTLC
+        # cells are *not* on outputs[0], so we scan every output of the
+        # force-close commitment tx and check whether the counterparty's
+        # watchtower has spent it on-chain. The PR-1335 fix is what keeps
+        # fiber2's preimage alive long enough to do that.
+        ckb_client = self.node.getClient()
+        force_tx_outputs = ckb_client.get_transaction(force_tx)["transaction"][
+            "outputs"
+        ]
+
+        def _find_settle_consumer():
+            for idx, out in enumerate(force_tx_outputs):
+                txs = ckb_client.get_transactions(
+                    {
+                        "script": out["lock"],
+                        "script_type": "lock",
+                        "script_search_mode": "exact",
+                    },
+                    "asc",
+                    "0xff",
+                    None,
+                )["objects"]
+                # The lock should appear once as output (in force_tx)
+                # and a second time as input in the watchtower settle tx.
+                consumer = next(
+                    (
+                        t
+                        for t in txs
+                        if t["io_type"] == "input" and t["tx_hash"] != force_tx
+                    ),
+                    None,
+                )
+                if consumer is not None:
+                    return idx, consumer["tx_hash"]
+            return None, None
+
+        # Mine plenty of blocks so the watchtower interval fires and the
+        # preimage-unlock tx lands on-chain. HTLC outputs are not behind a
+        # commit-lock timelock, so they can be spent immediately after the
+        # force-close lands.
+        deadline = time.time() + 300
+        spent_idx = consumer_tx = None
+        while time.time() < deadline:
+            for _ in range(120):
+                self.Miner.miner_with_version(self.node, "0x0")
+            time.sleep(5)
+            spent_idx, consumer_tx = _find_settle_consumer()
+            if consumer_tx is not None:
+                break
+        assert consumer_tx is not None, (
+            "no follow-up tx ever spent any output of the force-close "
+            "commitment tx — fiber2's watchtower did not settle the "
+            "on-chain HTLC using the retained preimage"
+        )
+
+        # Verify the consuming tx settles roughly the on-chain split amount
+        # out of the spent HTLC cell (tolerate tx fee < 1 CKB). The
+        # watchtower tx may also carry unrelated wallet inputs/outputs, so
+        # compare the spent cell against the small leftover output created
+        # from that same cell instead of netting the whole transaction.
+        settle_msg = self.get_tx_message(consumer_tx)
+        spent_capacity = int(force_tx_outputs[spent_idx]["capacity"], 16)
+        leftover_outputs = [
+            cell["capacity"]
+            for cell in settle_msg["output_cells"]
+            if cell["capacity"] < spent_capacity
+        ]
+        assert leftover_outputs, (
+            "watchtower settle tx did not produce a leftover output from "
+            f"the spent HTLC cell; outputs={settle_msg['output_cells']}"
+        )
+        settled_amount = spent_capacity - min(leftover_outputs)
+        assert abs(settled_amount - split_amount) < 100000000, (
+            f"watchtower settle tx settled {settled_amount} shannons, "
+            f"expected ~{split_amount} (on-chain split amount)"
+        )


### PR DESCRIPTION
## Summary
- add v0.9.0 migration regression tests
- add PR1262 installer regression and testnet smoke coverage
- add v0.9.0 focused regression suites
- run migration tests in the fiber CI workflow

## Verification
- `black --check .`
- `pytest --collect-only -q test_cases/fiber/devnet/migration test_cases/fiber/testnet/test_install_script.py test_cases/fiber/testnet/test_install_script_options.py`
