### PR TITLE
Add v0.9.0 migration and install script tests

### DIFF
--- a/.github/workflows/fiber.yml
+++ b/.github/workflows/fiber.yml
@@ -651,6 +651,42 @@ jobs:
           name: jfoa-fiber_open_channel_with_external_funding_mixed-reports-${{ runner.os }}
           path: ./report
 
+  fiber_test_migration:
+    needs: prepare
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Download prepare backup
+        uses: actions/download-artifact@v4
+        with:
+          name: prepare-backup-${{ runner.os }}
+          path: ./
+
+      - name: Extract tarball and restore permissions
+        run: |
+          tar -xzf prepare-backup.tar.gz
+
+      - name: Run migration tests
+        run: make fiber_test_demo FIBER_TEST_DEMO="test_cases/fiber/devnet/migration"
+
+      - name: Publish reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jfoa-migration-reports-${{ runner.os }}
+          path: ./report
+
   fiber_test_fnn_cli:
     needs: prepare
     runs-on: ubuntu-22.04
@@ -731,4 +767,3 @@ jobs:
         with:
           name: jfoa-proxy-tor-reports-${{ runner.os }}
           path: ./report
-

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ fiber_test_cases := \
 	test_cases/fiber/devnet/shutdown_channel \
 	test_cases/fiber/devnet/update_channel \
 	test_cases/fiber/devnet/issue \
+	test_cases/fiber/devnet/migration \
 	test_cases/fiber/devnet/watch_tower \
 	test_cases/fiber/devnet/fee_stats \
 	test_cases/fiber/devnet/fnn-cli

--- a/framework/test_fiber.py
+++ b/framework/test_fiber.py
@@ -72,6 +72,11 @@ class FiberConfigPath(Enum):
         "download/fiber/0.7.0/fnn",
     )
 
+    V081_DEV = (
+        "/source/fiber/dev_config_3.yml.j2",
+        "download/fiber/0.8.1/fnn",
+    )
+
     V061_DEV = (
         "/source/fiber/dev_config_3.yml.j2",
         "download/fiber/0.6.1/fnn",

--- a/test_cases/fiber/devnet/migration/_helpers.py
+++ b/test_cases/fiber/devnet/migration/_helpers.py
@@ -1,0 +1,305 @@
+"""Shared helpers for the PR #1323 (Unified Migration System) regression tests.
+
+These tests cover the new auto-migration flow introduced in fnn v0.9.x:
+- A `fnn` binary built after PR #1323 no longer ships a standalone `fnn-migrate`
+  for migrations >= INIT_DB_VERSION; instead it auto-migrates on startup with a
+  confirm/progress callback (`MigrateConfirmFn` / `MigrateProgressFn`).
+- For databases older than INIT_DB_VERSION (anything from <= v0.7.x), the user
+  must first run the legacy `fnn-migrate` from the v0.8.x release line.
+- The first migration that runs through the new system is the channel actor data
+  migration (0.8.1 -> 0.9.0-rc2), which adds `connectivity_state` and
+  `external_funding` fields to every persisted `ChannelActorData`.
+
+Helpers in this file deliberately stay shell-driven so that they exercise
+exactly what a real operator would do (`echo y | fnn ...`).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import requests
+
+from framework.basic_fiber import FiberTest, XUDT_TX_HASH
+from framework.config import DEFAULT_MIN_DEPOSIT_CKB
+from framework.helper.udt_contract import UdtContract
+from framework.util import get_project_root
+
+MIG_VERSION_KEY_FILE_HINT = "db-version"
+INIT_DB_VERSION = "20260302100001"
+LATEST_DB_VERSION_AFTER_PR1323 = "20260518120000"
+
+
+class MigrationFiberTest(FiberTest):
+    """FiberTest variant for migration tests that start their own nodes."""
+
+    def setup_method(self, method):
+        print("setup_method")
+        self.did_pass = None
+        self.beginNum = hex(self.node.getClient().get_tip_block_number())
+        self.fibers = []
+        self.new_fibers = []
+        self.udtContract = UdtContract(XUDT_TX_HASH, 0)
+        if self.debug:
+            return
+        self.node.getClient().clear_tx_pool()
+        self.node.start_miner()
+        self.logger.debug(f"\nSetting up method:{method.__name__}")
+
+
+def fiber_store_dir(fiber) -> Path:
+    """Path to the RocksDB store directory of a Fiber node."""
+    return Path(fiber.tmp_path) / "fiber" / "store"
+
+
+def node_log_path(fiber) -> Path:
+    return Path(fiber.tmp_path) / "node.log"
+
+
+def read_node_log(fiber) -> str:
+    p = node_log_path(fiber)
+    if not p.exists():
+        return ""
+    return p.read_text(errors="replace")
+
+
+def assert_log_contains(fiber, needle: str):
+    log = read_node_log(fiber)
+    assert needle in log, (
+        f"expected substring not found in node.log: {needle!r}\n"
+        f"--- log tail ---\n{log[-4000:]}"
+    )
+
+
+def assert_log_matches(fiber, pattern: str):
+    log = read_node_log(fiber)
+    assert re.search(pattern, log), (
+        f"expected regex not matched in node.log: {pattern!r}\n"
+        f"--- log tail ---\n{log[-4000:]}"
+    )
+
+
+def wait_log_matches(fiber, pattern: str, timeout=20):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        log = read_node_log(fiber)
+        if re.search(pattern, log):
+            return
+        time.sleep(0.2)
+    assert_log_matches(fiber, pattern)
+
+
+def fiber_bin_exists(rel_path: str) -> bool:
+    return os.path.isfile(os.path.join(get_project_root(), rel_path))
+
+
+def rpc_call_with_timeout(fiber, method, params, timeout=10):
+    response = requests.post(
+        f"http://127.0.0.1:{fiber.rpc_port}",
+        json={"id": 42, "jsonrpc": "2.0", "method": method, "params": params},
+        headers={"content-type": "application/json"},
+        timeout=timeout,
+    ).json()
+    if "error" in response:
+        raise Exception(response["error"].get("message", response["error"]))
+    return response.get("result")
+
+
+def list_channels_with_timeout(fiber, timeout=10):
+    return rpc_call_with_timeout(fiber, "list_channels", [{}], timeout)["channels"]
+
+
+def wait_peer_connected(fiber, min_count=1, timeout=10):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        peers = fiber.get_client().list_peers()["peers"]
+        if len(peers) >= min_count:
+            return peers
+        time.sleep(0.2)
+    peers = fiber.get_client().list_peers()["peers"]
+    raise TimeoutError(
+        "expected at least {} connected peers, got {}".format(min_count, peers)
+    )
+
+
+def wait_channels_ready(fiber, expected_count=1, timeout=60):
+    ready_states = {"ChannelReady", "CHANNEL_READY"}
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        channels = list_channels_with_timeout(fiber)
+        ready = [c for c in channels if c["state"]["state_name"] in ready_states]
+        if len(ready) >= expected_count:
+            return channels
+        time.sleep(1)
+    channels = list_channels_with_timeout(fiber)
+    raise TimeoutError(
+        "expected at least {} ready channels, got {}".format(expected_count, channels)
+    )
+
+
+def open_v070_channel(opener, balance):
+    peer_id = opener.get_client().list_peers()["peers"][0]["peer_id"]
+    opener.get_client().open_channel(
+        {
+            "peer_id": peer_id,
+            "funding_amount": hex(balance + DEFAULT_MIN_DEPOSIT_CKB),
+            "public": True,
+        }
+    )
+
+
+def send_invoice_payment_with_timeout(test_case, fiber1, fiber2, amount, timeout=45):
+    invoice = rpc_call_with_timeout(
+        fiber2,
+        "new_invoice",
+        [
+            {
+                "amount": hex(amount),
+                "currency": "Fibd",
+                "description": "migration liveness check invoice",
+                "payment_preimage": test_case.generate_random_preimage(),
+                "hash_algorithm": "sha256",
+                "allow_mpp": True,
+            }
+        ],
+    )
+    payment = rpc_call_with_timeout(
+        fiber1,
+        "send_payment",
+        [
+            {
+                "invoice": invoice["invoice_address"],
+                "allow_self_payment": True,
+                "max_parts": hex(12),
+                "max_fee_rate": hex(1000000000000000),
+            }
+        ],
+    )
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = rpc_call_with_timeout(
+            fiber1,
+            "get_payment",
+            [{"payment_hash": payment["payment_hash"]}],
+        )
+        if result["status"] == "Success":
+            return payment["payment_hash"]
+        if result["status"] == "Failed":
+            raise Exception(f"payment failed: {result}")
+        time.sleep(1)
+    raise TimeoutError(
+        "payment:{} status did not reach Success within {}s".format(
+            payment["payment_hash"], timeout
+        )
+    )
+
+
+def send_invoice_payment_with_retry(test_case, fiber1, fiber2, amount, timeout=60):
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            return send_invoice_payment_with_timeout(
+                test_case, fiber1, fiber2, amount, timeout=15
+            )
+        except Exception as e:
+            last_error = e
+            time.sleep(1)
+    raise TimeoutError(f"payment did not succeed within {timeout}s: {last_error}")
+
+
+def start_with_confirm(
+    fiber,
+    confirm="y",
+    password="password0",
+    fnn_log_level="debug",
+    timeout=300,
+):
+    """Start fnn and answer the migration confirm prompt.
+
+    This is local to migration tests because normal Fiber tests should keep
+    using `fiber.start()`.
+    """
+    env = os.environ.copy()
+    env["FIBER_SECRET_KEY_PASSWORD"] = password
+    env["RUST_LOG"] = f"info,fnn={fnn_log_level}"
+    log_path = node_log_path(fiber)
+    cmd = [
+        f"{get_project_root()}/{fiber.fiber_config_enum.fiber_bin_path}",
+        "-c",
+        f"{fiber.tmp_path}/config.yml",
+        "-d",
+        fiber.tmp_path,
+    ]
+
+    log_file = open(log_path, "ab")
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    log_file.close()
+
+    if proc.stdin is not None:
+        try:
+            proc.stdin.write(f"{confirm}\n".encode())
+            proc.stdin.close()
+        except BrokenPipeError:
+            pass
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(1)
+            if s.connect_ex(("127.0.0.1", int(fiber.rpc_port))) == 0:
+                return
+
+        exit_code = proc.poll()
+        if exit_code is not None:
+            raise RuntimeError(
+                f"Fiber exited before RPC port {fiber.rpc_port} opened "
+                f"(exit code {exit_code}).\n--- node.log tail ---\n"
+                f"{read_node_log(fiber)[-4000:]}"
+            )
+        time.sleep(0.3)
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    raise TimeoutError(
+        f"Port {fiber.rpc_port} did not become open within {timeout}s.\n"
+        f"--- node.log tail ---\n{read_node_log(fiber)[-4000:]}"
+    )
+
+
+def start_blocking(
+    fiber,
+    confirm="n",
+    password="password0",
+    fnn_log_level="info",
+    timeout=60,
+):
+    cmd = (
+        f"echo {confirm} | FIBER_SECRET_KEY_PASSWORD='{password}' "
+        f"RUST_LOG=info,fnn={fnn_log_level} "
+        f"{get_project_root()}/{fiber.fiber_config_enum.fiber_bin_path} "
+        f"-c {fiber.tmp_path}/config.yml -d {fiber.tmp_path}"
+    )
+    proc = subprocess.run(
+        cmd,
+        shell=True,
+        timeout=timeout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    out = proc.stdout.decode("utf-8", errors="replace") if proc.stdout else ""
+    return proc.returncode, out

--- a/test_cases/fiber/devnet/migration/test_auto_migrate_from_v081.py
+++ b/test_cases/fiber/devnet/migration/test_auto_migrate_from_v081.py
@@ -1,0 +1,96 @@
+"""PR #1323/#1355 regression: auto-migrate from v0.8.1 to current.
+
+Scenario:
+  1. Start a pair of v0.8.1 fnn nodes, open a channel, exchange payments so the
+     RocksDB store contains real ChannelActorData (old layout).
+  2. Stop both nodes.
+  3. Switch the binary to current WITHOUT running the old
+     standalone `fnn-migrate` tool.
+  4. Start each node again. The new auto-migration must:
+       - present a confirmation prompt on stderr (we pipe "y"),
+       - run the latest channel actor data migration against the existing
+         ChannelActorData entries,
+       - leave db-version at LATEST_DB_VERSION_AFTER_PR1323.
+  5. After both nodes are up, the channel must still be alive and a fresh
+     payment must succeed in both directions.
+"""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    send_invoice_payment_with_timeout,
+    start_with_confirm,
+    wait_log_matches,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestAutoMigrateFromV081(MigrationFiberTest):
+    def test_auto_migrate_v081_to_current(self):
+        # 1. start two v0.8.1 nodes
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+
+        # 2. open a public channel and exercise it so ChannelActorData is on disk
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0)
+        self.send_invoice_payment(old_a, old_b, 1)
+        self.send_invoice_payment(old_b, old_a, 1)
+
+        old_channel_count = len(old_a.get_client().list_channels({})["channels"])
+        assert old_channel_count >= 1
+
+        old_a.stop()
+        old_b.stop()
+
+        # 3. switch binary to current WITHOUT running fnn-migrate
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+
+        # 4. start with auto-confirm; auto-migration must succeed
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+
+        # the migration plan + step messages should have been logged
+        wait_log_matches(old_a, r"Database migration required")
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(
+            old_a, r"Migration {} complete".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_a, r"connectivity_state and external_funding")
+
+        # 5. channel survived the migration and is still usable via RPC
+        chans = list_channels_with_timeout(old_a)
+        assert len(chans) == old_channel_count, "channel must survive migration"
+        assert all(c["state"]["state_name"] == "ChannelReady" for c in chans), chans
+
+        # 6. fresh payments must work in both directions
+        send_invoice_payment_with_timeout(self, old_a, old_b, 1)
+        send_invoice_payment_with_timeout(self, old_b, old_a, 1)
+
+        # 7. starting again should NOT trigger another migration
+        old_a.stop()
+        start_with_confirm(old_a, confirm="y")
+        log = open(f"{old_a.tmp_path}/node.log").read()
+        # after a clean second startup we expect the "is current, no migration
+        # needed" branch (or at least no new "Migrating to" line for the same
+        # version a second time)
+        assert (
+            log.count("Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)) == 1
+        ), "auto-migration must be idempotent on second startup"

--- a/test_cases/fiber/devnet/migration/test_large_u128_channel_constraints.py
+++ b/test_cases/fiber/devnet/migration/test_large_u128_channel_constraints.py
@@ -1,0 +1,89 @@
+"""PR #1355 regression: explicit large u128 channel constraints must migrate.
+
+This covers the bug class fixed by avoiding JSON round-trips in channel data
+migration. A v0.8.1 channel can persist u128-sized constraint fields; current
+fnn must migrate that data and still read the channel normally.
+"""
+
+import time
+
+import pytest
+
+from framework.config import DEFAULT_MIN_DEPOSIT_CKB
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    send_invoice_payment_with_timeout,
+    start_with_confirm,
+    wait_log_matches,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestLargeU128ChannelConstraints(MigrationFiberTest):
+    def test_auto_migrate_v081_explicit_max_tlc_value_in_flight(self):
+        large_max_tlc_value = (1 << 128) - 1
+
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a)
+
+        temporary_channel = old_a.get_client().open_channel(
+            {
+                "pubkey": old_b.get_pubkey(),
+                "funding_amount": hex(DEFAULT_MIN_DEPOSIT_CKB + 10 * 100000000),
+                "public": True,
+                "max_tlc_value_in_flight": hex(large_max_tlc_value),
+            }
+        )
+        time.sleep(1)
+        old_b.get_client().accept_channel(
+            {
+                "temporary_channel_id": temporary_channel["temporary_channel_id"],
+                "funding_amount": hex(1000 * 100000000),
+                "max_tlc_value_in_flight": hex(large_max_tlc_value),
+            }
+        )
+        self.wait_for_channel_state(
+            old_a.get_client(), old_b.get_pubkey(), "ChannelReady"
+        )
+
+        self.send_invoice_payment(old_a, old_b, 1, False)
+        self.send_invoice_payment(old_b, old_a, 1, False)
+        old_channel_count = len(old_a.get_client().list_channels({})["channels"])
+        assert old_channel_count >= 1
+
+        old_a.stop()
+        old_b.stop()
+
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_a, r"connectivity_state and external_funding")
+
+        chans = list_channels_with_timeout(old_a)
+        assert len(chans) == old_channel_count, "channel must survive migration"
+        assert all(c["state"]["state_name"] == "ChannelReady" for c in chans), chans
+
+        send_invoice_payment_with_timeout(self, old_a, old_b, 1)
+        send_invoice_payment_with_timeout(self, old_b, old_a, 1)

--- a/test_cases/fiber/devnet/migration/test_legacy_migrate_archived.py
+++ b/test_cases/fiber/devnet/migration/test_legacy_migrate_archived.py
@@ -1,0 +1,37 @@
+"""PR #1323 archive sanity: the legacy `fnn-migrate` binary must NOT be shipped
+inside the v0.9.0+ release tarball anymore (the `migrate/` workspace was renamed
+to `migrate_archive/` and removed from CI). The v0.8.x release line keeps it.
+
+This test asserts the on-disk layout that download_fiber.py extracts.
+"""
+
+import os
+
+import pytest
+
+from framework.util import get_project_root
+
+
+def _exists(rel: str) -> bool:
+    return os.path.isfile(os.path.join(get_project_root(), rel))
+
+
+class TestLegacyMigrateArchived:
+    def test_v081_release_still_ships_fnn_migrate(self):
+        if not _exists("download/fiber/0.8.1/fnn"):
+            pytest.skip("v0.8.1 not downloaded")
+        assert _exists(
+            "download/fiber/0.8.1/fnn-migrate"
+        ), "v0.8.1 release MUST keep fnn-migrate (used as the bridge tool)"
+
+    def test_current_release_no_longer_ships_fnn_migrate(self):
+        if not _exists("download/fiber/current/fnn"):
+            pytest.skip("current binary not downloaded")
+        # PR #1323 archives the standalone tool. If a future release brings it
+        # back, this test will flip to a green dot once the assertion is
+        # inverted -- but for now its absence is part of the contract.
+        assert not _exists("download/fiber/current/fnn-migrate"), (
+            "PR #1323 removed standalone fnn-migrate from the new release; "
+            "found it again under download/fiber/current/. "
+            "If this is intentional, update this assertion."
+        )

--- a/test_cases/fiber/devnet/migration/test_multi_channel_migration.py
+++ b/test_cases/fiber/devnet/migration/test_multi_channel_migration.py
@@ -1,0 +1,68 @@
+"""PR #1355 regression: multiple channel actor records migrate together."""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    send_invoice_payment_with_retry,
+    start_with_confirm,
+    wait_log_matches,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestMultiChannelMigration(MigrationFiberTest):
+    def test_auto_migrate_v081_three_node_route(self):
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_c = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0)
+        self.open_channel(old_b, old_c, 1000 * 100000000, 0)
+        send_invoice_payment_with_retry(self, old_a, old_c, 1)
+
+        old_b_channel_count = len(old_b.get_client().list_channels({})["channels"])
+        assert old_b_channel_count >= 2
+
+        old_a.stop()
+        old_b.stop()
+        old_c.stop()
+
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_c.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+        start_with_confirm(old_c, confirm="y")
+        old_a.connect_peer(old_b)
+        old_b.connect_peer(old_c)
+        wait_peer_connected(old_a)
+        wait_peer_connected(old_b)
+
+        wait_log_matches(
+            old_b, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_b, r"connectivity_state and external_funding")
+
+        channels = list_channels_with_timeout(old_b)
+        assert len(channels) == old_b_channel_count, "all channels must survive"
+        assert all(c["state"]["state_name"] == "ChannelReady" for c in channels)
+
+        send_invoice_payment_with_retry(self, old_a, old_c, 1)

--- a/test_cases/fiber/devnet/migration/test_new_db_stamps_latest.py
+++ b/test_cases/fiber/devnet/migration/test_new_db_stamps_latest.py
@@ -1,0 +1,41 @@
+"""PR #1323 regression: a brand-new database (no `db-version` key) must be
+stamped with LATEST_DB_VERSION on first open and must NOT prompt the user.
+A second start must be a no-op (`Database version ... is current, no migration
+needed`).
+"""
+
+from ._helpers import (
+    fiber_store_dir,
+    MigrationFiberTest,
+    read_node_log,
+    start_with_confirm,
+)
+
+
+class TestNewDbStampsLatest(MigrationFiberTest):
+    def test_new_db_no_migration_needed(self):
+        fiber = self.start_new_fiber(self.account1_private_key)
+
+        # The current binary started against an empty data dir, so the
+        # auto_migrate "no db-version -> stamp LATEST" branch must have run.
+        store = fiber_store_dir(fiber)
+        assert store.exists(), "fiber1 store must exist after first startup"
+
+        # No migration plan / progress lines should appear in the log because
+        # the DB is brand-new.
+        log1 = read_node_log(fiber)
+        assert "Database migration required" not in log1
+        assert "Migrating to" not in log1
+
+        # Second startup must hit the "is current, no migration needed" branch.
+        fiber.stop()
+        start_with_confirm(fiber, confirm="n")  # would cancel if asked
+
+        log2 = read_node_log(fiber)
+        assert (
+            "Database migration required" not in log2
+        ), "auto_migrate must NOT prompt when db-version already equals LATEST"
+        # the framework startup may or may not log the exact phrase; the strong
+        # contract is: the node is up and answering RPC.
+        info = fiber.get_client().node_info()
+        assert "node_id" in info or "pubkey" in info

--- a/test_cases/fiber/devnet/migration/test_newer_db_rejected.py
+++ b/test_cases/fiber/devnet/migration/test_newer_db_rejected.py
@@ -1,0 +1,49 @@
+"""PR #1323 sanity check: starting against an artificially "future" db-version
+must abort with `MigrateError::DatabaseTooNew` instead of silently downgrading
+the user.
+
+We simulate a future db-version by directly writing into RocksDB after stopping
+the node. To stay backend-agnostic, we only assert on the user-visible behavior
+(non-zero exit + `too new` / "newer" diagnostic), not on the exact RocksDB key
+format.
+
+If your CI doesn't ship `python-rocksdb`, this test is automatically skipped.
+"""
+
+import pytest
+
+from ._helpers import (
+    fiber_store_dir,
+    MigrationFiberTest,
+    read_node_log,
+    start_blocking,
+)
+
+rocksdb = pytest.importorskip(
+    "rocksdict",
+    reason="rocksdict not installed; install with `pip install rocksdict` to run",
+)
+
+
+class TestNewerDbRejected(MigrationFiberTest):
+    def test_future_db_version_rejected(self):
+        # Start current fnn against a fresh DB, then stop it so we can rewrite
+        # db-version to a future value.
+        fiber = self.start_new_fiber(self.account1_private_key)
+        fiber.stop()
+
+        # write a future db-version into the RocksDB store directly
+        future_version = "29991231235959"
+        store_path = str(fiber_store_dir(fiber))
+        db = rocksdb.Rdict(store_path)
+        try:
+            db[b"db-version"] = future_version.encode()
+        finally:
+            db.close()
+
+        exit_code, output = start_blocking(fiber, confirm="y", timeout=60)
+        assert exit_code != 0, "fnn must NOT start when db is newer than binary"
+        log = output + "\n" + read_node_log(fiber)
+        assert (
+            "newer" in log.lower() or "too new" in log.lower() or future_version in log
+        ), f"expected DatabaseTooNew diagnostic, got:\n{log[-2000:]}"

--- a/test_cases/fiber/devnet/migration/test_old_db_rejected.py
+++ b/test_cases/fiber/devnet/migration/test_old_db_rejected.py
@@ -1,0 +1,68 @@
+"""PR #1323 regression: starting current fnn against an old (< INIT_DB_VERSION)
+database must fail fast with a clear `DatabaseTooOld` style message instead of
+silently corrupting the store or hanging.
+
+We use a v0.7.0 database, since its highest db-version is well below
+INIT_DB_VERSION = 20260302100001.
+"""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    INIT_DB_VERSION,
+    fiber_bin_exists,
+    MigrationFiberTest,
+    open_v070_channel,
+    read_node_log,
+    start_blocking,
+    wait_channels_ready,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.7.0/fnn"),
+    reason="v0.7.0 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestOldDbRejected(MigrationFiberTest):
+    def test_v070_db_directly_against_current_is_rejected(self):
+        # 1. produce a real v0.7.0 store
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V070_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V070_DEV
+        )
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a)
+        open_v070_channel(old_a, 1000 * 100000000)
+        wait_channels_ready(old_a)
+        old_a.stop()
+        old_b.stop()
+
+        # 2. switch to current binary WITHOUT running v0.8.x fnn-migrate
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+
+        # 3. starting must fail. We pipe "y" so that, if for some reason the
+        #    binary still asks for confirmation, we are not the cause of the
+        #    failure. The expected exit comes from MigrateError::DatabaseTooOld.
+        exit_code, output = start_blocking(old_a, confirm="y", timeout=60)
+        assert exit_code != 0, "fnn must NOT start against a pre-INIT_DB_VERSION DB"
+
+        log = output + "\n" + read_node_log(old_a)
+        # message format from MigrateError::DatabaseTooOld
+        assert (
+            "too old" in log.lower()
+            or INIT_DB_VERSION in log
+            or "fnn-migrate" in log.lower()
+        ), f"expected DatabaseTooOld diagnostic, got log:\n{log[-2000:]}"
+
+        # the user-facing hint should point at the correct legacy tool version
+        # (design says v0.7.x, current code says v0.8.x -- this assertion
+        # locks the contract; flip the literal if the project chooses one).
+        assert (
+            "v0.7" in log or "v0.8" in log
+        ), "DatabaseTooOld must point users at the legacy fnn-migrate version"

--- a/test_cases/fiber/devnet/migration/test_pending_hold_invoice_migration.py
+++ b/test_cases/fiber/devnet/migration/test_pending_hold_invoice_migration.py
@@ -1,0 +1,84 @@
+"""PR #1355 regression: pending TLC state can be resumed after migration."""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+from test_cases.fiber.devnet.settle_invoice.test_settle_invoice import sha256_hex
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    start_with_confirm,
+    wait_log_matches,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestPendingHoldInvoiceMigration(MigrationFiberTest):
+    def test_auto_migrate_v081_pending_hold_invoice(self):
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0)
+        preimage = self.generate_random_preimage()
+        payment_hash = sha256_hex(preimage)
+        invoice = old_b.get_client().new_invoice(
+            {
+                "amount": hex(1 * 100000000),
+                "currency": "Fibd",
+                "description": "migration hold invoice",
+                "expiry": hex(3600),
+                "final_cltv": hex(40),
+                "payment_hash": payment_hash,
+                "hash_algorithm": "sha256",
+            }
+        )
+        payment = old_a.get_client().send_payment(
+            {"invoice": invoice["invoice_address"]}
+        )
+        self.wait_invoice_state(old_b, payment_hash, "Received", 120, 1)
+        old_channels = old_a.get_client().list_channels({})["channels"]
+        assert len(old_channels[0]["pending_tlcs"]) >= 1
+
+        old_a.stop()
+        old_b.stop()
+
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a)
+
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_a, r"connectivity_state and external_funding")
+
+        channels = list_channels_with_timeout(old_a)
+        assert len(channels) == len(old_channels), "channel must survive migration"
+        assert channels[0]["state"]["state_name"] == "ChannelReady"
+
+        invoice_after_restart = old_b.get_client().get_invoice(
+            {"payment_hash": payment_hash}
+        )
+        assert invoice_after_restart["status"] == "Received"
+
+        old_b.get_client().settle_invoice(
+            {"payment_hash": payment_hash, "payment_preimage": preimage}
+        )
+        self.wait_payment_state(old_a, payment["payment_hash"], "Success", 120, 1)
+        invoice_paid = old_b.get_client().get_invoice({"payment_hash": payment_hash})
+        assert invoice_paid["status"] == "Paid"

--- a/test_cases/fiber/devnet/migration/test_two_step_upgrade_from_v070.py
+++ b/test_cases/fiber/devnet/migration/test_two_step_upgrade_from_v070.py
@@ -1,0 +1,75 @@
+"""PR #1323/#1355 regression: the documented two-step upgrade path
+v0.7.0 -> (run v0.8.x `fnn-migrate`) -> current must succeed end-to-end.
+
+This is the upgrade path PR #1323 explicitly preserves: pre-INIT_DB_VERSION
+databases must first be brought up to INIT_DB_VERSION using the legacy
+standalone migrate tool from a v0.8.x release, then the current binary's
+auto-migration takes over for everything from INIT_DB_VERSION onward
+(currently the channel actor data migration).
+"""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    open_v070_channel,
+    send_invoice_payment_with_timeout,
+    start_with_confirm,
+    wait_channels_ready,
+    wait_log_matches,
+    wait_peer_connected,
+)
+
+pytestmark = pytest.mark.skipif(
+    not (
+        fiber_bin_exists("download/fiber/0.7.0/fnn")
+        and fiber_bin_exists("download/fiber/0.8.1/fnn-migrate")
+    ),
+    reason="v0.7.0 fnn and v0.8.1 fnn-migrate must both be present",
+)
+
+
+class TestTwoStepUpgradeFromV070(MigrationFiberTest):
+    def test_v070_then_v081_migrate_then_current_autostart(self):
+        # 1. v0.7.0 phase: real channel data on disk
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V070_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V070_DEV
+        )
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a)
+        open_v070_channel(old_a, 1000 * 100000000)
+        wait_channels_ready(old_a)
+        self.send_invoice_payment(old_a, old_b, 1)
+        self.send_invoice_payment(old_b, old_a, 1)
+        old_a.stop()
+        old_b.stop()
+
+        # 2. step 1 of upgrade: legacy fnn-migrate from v0.8.1
+        old_a.fiber_config_enum = FiberConfigPath.V081_DEV
+        old_b.fiber_config_enum = FiberConfigPath.V081_DEV
+        old_a.migration()
+        old_b.migration()
+
+        # 3. step 2 of upgrade: switch to current and let auto-migrate finish
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+
+        # 4. liveness checks
+        chans = list_channels_with_timeout(old_a)
+        assert len(chans) >= 1, "channel must survive the two-step upgrade"
+        send_invoice_payment_with_timeout(self, old_a, old_b, 1)
+        send_invoice_payment_with_timeout(self, old_b, old_a, 1)

--- a/test_cases/fiber/devnet/migration/test_udt_channel_migration.py
+++ b/test_cases/fiber/devnet/migration/test_udt_channel_migration.py
@@ -1,0 +1,58 @@
+"""PR #1355 regression: UDT channel data must survive auto-migration."""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    LATEST_DB_VERSION_AFTER_PR1323,
+    assert_log_matches,
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    start_with_confirm,
+    wait_log_matches,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestUdtChannelMigration(MigrationFiberTest):
+    def test_auto_migrate_v081_udt_channel(self):
+        udt_script = self.get_account_udt_script(self.account1_private_key)
+        old_a = self.start_new_fiber(
+            self.generate_account(10000, self.account1_private_key, 2000 * 100000000),
+            fiber_version=FiberConfigPath.V081_DEV,
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0, udt=udt_script)
+        self.send_payment(old_a, old_b, 1 * 100000000, udt=udt_script)
+        old_channels = old_a.get_client().list_channels({})["channels"]
+        assert len(old_channels) >= 1
+        assert old_channels[0]["funding_udt_type_script"] == udt_script
+
+        old_a.stop()
+        old_b.stop()
+
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+        start_with_confirm(old_a, confirm="y")
+        start_with_confirm(old_b, confirm="y")
+
+        wait_log_matches(
+            old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
+        )
+        assert_log_matches(old_a, r"connectivity_state and external_funding")
+
+        channels = list_channels_with_timeout(old_a)
+        assert len(channels) == len(old_channels), "UDT channel must survive migration"
+        assert channels[0]["state"]["state_name"] == "ChannelReady"
+        assert channels[0]["funding_udt_type_script"] == udt_script
+
+        self.send_payment(old_a, old_b, 1 * 100000000, udt=udt_script)

--- a/test_cases/fiber/devnet/migration/test_user_cancel_migration.py
+++ b/test_cases/fiber/devnet/migration/test_user_cancel_migration.py
@@ -1,0 +1,52 @@
+"""PR #1323 regression: when the user declines the migration confirm prompt,
+fnn must abort with `MigrateError::UserCancelled` and must NOT touch the data.
+"""
+
+import pytest
+
+from framework.test_fiber import FiberConfigPath
+
+from ._helpers import (
+    fiber_bin_exists,
+    list_channels_with_timeout,
+    MigrationFiberTest,
+    start_blocking,
+    start_with_confirm,
+    wait_channels_ready,
+)
+
+pytestmark = pytest.mark.skipif(
+    not fiber_bin_exists("download/fiber/0.8.1/fnn"),
+    reason="v0.8.1 binary not downloaded (run download_fiber.py first)",
+)
+
+
+class TestUserCancelMigration(MigrationFiberTest):
+    def test_decline_migration_aborts_startup(self):
+        # 1. produce a v0.8.1 store (db-version == INIT_DB_VERSION)
+        old_a = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        old_b = self.start_new_fiber(
+            self.generate_account(10000), fiber_version=FiberConfigPath.V081_DEV
+        )
+        self.open_channel(old_a, old_b, 1000 * 100000000, 0)
+        wait_channels_ready(old_a)
+        old_a.stop()
+        old_b.stop()
+
+        # 2. switch to current and decline the prompt
+        old_a.fiber_config_enum = FiberConfigPath.CURRENT_DEV
+
+        exit_code, output = start_blocking(old_a, confirm="n", timeout=60)
+        assert exit_code != 0, "fnn must NOT start when user declines migration"
+        assert (
+            "cancel" in output.lower() or "usercancelled" in output.lower()
+        ), f"expected UserCancelled in output, got:\n{output[-2000:]}"
+
+        # 3. flipping the answer to "y" on a retry must succeed and the channel
+        #    data must still be readable (the cancelled run must not have
+        #    partially written anything corrupting).
+        start_with_confirm(old_a, confirm="y")
+        chans = list_channels_with_timeout(old_a)
+        assert len(chans) >= 1, "channel must survive a previously cancelled migration"

--- a/test_cases/fiber/testnet/test_install_script.py
+++ b/test_cases/fiber/testnet/test_install_script.py
@@ -1,0 +1,738 @@
+"""PR #1262 testnet installer regression test.
+
+Default runs cover the installer/startup smoke path. The full real testnet
+channel/payment/close acceptance flow is opt-in because it opens and closes a
+real public testnet channel.
+
+Run the live flow explicitly with:
+    FIBER_PR1262_RUN_LIVE_CHANNEL=1 pytest -q \
+        test_cases/fiber/testnet/test_install_script.py::TestPR1262InstallScript::test_install_script_installs_starts_opens_channel_and_sends_payment -s
+"""
+
+import os
+import re
+import signal
+import socket
+import stat
+import subprocess
+import textwrap
+import time
+import urllib.request
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional, Tuple
+
+import pytest
+
+from framework.fiber_rpc import FiberRPCClient
+from framework.rpc import RPCClient
+from framework.test_fiber import FiberConfigPath
+from framework.util import get_project_root
+
+DEFAULT_ACCOUNT_1 = {
+    "private_key": "ff86b08163503b9583cbcf48d70de24a1cbd7178f5a0107b976862a31e4b2007",
+    "mainnet_address": "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqfqrxdlsl87hs7ggycnapc9ztxrru472cgm63u4s",
+    "testnet_address": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqfqrxdlsl87hs7ggycnapc9ztxrru472cg4g6nlg",
+    "lock_arg": "0x20199bf87cfebc3c841313e870512cc31f2be561",
+    "lock_hash": "0x4e3b33be6d88bb16ef2e651d8c104d8b71627c1ade2781df2f8193779bd5bc8f",
+}
+DEFAULT_ACCOUNT_2 = {
+    "private_key": "bb063c2683104406b492573e1aa5714f433a9dbb5849f19a0a4fca7f5b6317b8",
+    "mainnet_address": "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqf36t5upsx5m25u4pnlhkcwwx5fqlssc0g8w8s5q",
+    "testnet_address": "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqf36t5upsx5m25u4pnlhkcwwx5fqlssc0gfuvl7c",
+    "lock_arg": "0x31d2e9c0c0d4daa9ca867fbdb0e71a8907e10c3d",
+    "lock_hash": "0xbd36bd29384889fa4990dde131ead4ae6cc85e4ce21dfa95b1cec36934ad1c96",
+}
+
+
+def configured_account(index, defaults):
+    private_key = os.environ.get(
+        f"FIBER_PR1262_ACCOUNT_PRIVATE_{index}", defaults["private_key"]
+    ).replace("0x", "")
+    use_defaults = private_key == defaults["private_key"]
+    return {
+        "index": index,
+        "private_key": private_key,
+        "mainnet_address": os.environ.get(
+            f"FIBER_PR1262_ACCOUNT_MAINNET_ADDRESS_{index}",
+            defaults["mainnet_address"] if use_defaults else "",
+        ),
+        "testnet_address": os.environ.get(
+            f"FIBER_PR1262_ACCOUNT_TESTNET_ADDRESS_{index}",
+            defaults["testnet_address"] if use_defaults else "",
+        ),
+        "lock_arg": os.environ.get(
+            f"FIBER_PR1262_ACCOUNT_LOCK_ARG_{index}",
+            defaults["lock_arg"] if use_defaults else "",
+        ),
+        "lock_hash": os.environ.get(
+            f"FIBER_PR1262_ACCOUNT_LOCK_HASH_{index}",
+            defaults["lock_hash"] if use_defaults else "",
+        ),
+    }
+
+
+ACCOUNT_1 = configured_account(1, DEFAULT_ACCOUNT_1)
+ACCOUNT_2 = configured_account(2, DEFAULT_ACCOUNT_2)
+ACCOUNT_PRIVATE_1 = ACCOUNT_1["private_key"]
+ACCOUNT_PRIVATE_2 = ACCOUNT_2["private_key"]
+CKB = 100000000
+PAYMENT_AMOUNT_SHANNON = 1000
+TESTNET_CKB_RPC_URL = "https://testnet.ckb.dev"
+RUN_LIVE_CHANNEL_ENV = "FIBER_PR1262_RUN_LIVE_CHANNEL"
+REFRESH_INSTALL_SH_ENV = "FIBER_PR1262_REFRESH_INSTALL_SH"
+INSTALL_SH_URL = (
+    "https://raw.githubusercontent.com/nervosnetwork/fiber/pull/1262/head"
+    "/tools/install/install.sh"
+)
+INSTALL_SH_CACHE_NAME = "nervosnetwork-fiber-pr-1262"
+_INSTALL_SH_PATH_CACHE = {}
+
+
+def install_sh_download_source():
+    return INSTALL_SH_URL, INSTALL_SH_CACHE_NAME
+
+
+def download_install_sh(url, cache_name):
+    cache_key = (url, cache_name)
+    cache_dir = Path(get_project_root()) / "download" / "fiber" / "install" / cache_name
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = cache_dir / "install.sh"
+    refresh = os.environ.get(REFRESH_INSTALL_SH_ENV) == "1"
+
+    cached_path = _INSTALL_SH_PATH_CACHE.get(cache_key)
+    if cached_path and cached_path.exists() and not refresh:
+        return cached_path
+
+    if path.exists() and not refresh:
+        _INSTALL_SH_PATH_CACHE[cache_key] = path
+        return path
+
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            path.write_bytes(response.read())
+    except Exception as err:
+        if path.exists():
+            _INSTALL_SH_PATH_CACHE[cache_key] = path
+            return path
+        pytest.fail(f"install.sh download failed: {url}: {err}")
+
+    _INSTALL_SH_PATH_CACHE[cache_key] = path
+    return path
+
+
+def install_sh_path():
+    return download_install_sh(*install_sh_download_source())
+
+
+def run_live_channel_test():
+    return os.environ.get(RUN_LIVE_CHANNEL_ENV) == "1"
+
+
+def local_fnn_path():
+    project_root = Path(get_project_root())
+    path = project_root / FiberConfigPath.CURRENT_TESTNET.fiber_bin_path
+    if path.exists() and (path.parent / "config" / "testnet" / "config.yml").exists():
+        return path
+
+    pytest.fail(
+        f"{FiberConfigPath.CURRENT_TESTNET.fiber_bin_path} with bundled testnet config not found"
+    )
+
+
+def free_tcp_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def write_executable(path, content):
+    path.write_text(textwrap.dedent(content).lstrip())
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def account_info_for_private_key(private_key):
+    private_key = private_key.replace("0x", "")
+    for account in (ACCOUNT_1, ACCOUNT_2):
+        if account["private_key"] == private_key:
+            missing = [
+                key
+                for key in (
+                    "mainnet_address",
+                    "testnet_address",
+                    "lock_arg",
+                    "lock_hash",
+                )
+                if not account[key]
+            ]
+            if missing:
+                missing_env_names = {
+                    "mainnet_address": f"FIBER_PR1262_ACCOUNT_MAINNET_ADDRESS_{account['index']}",
+                    "testnet_address": f"FIBER_PR1262_ACCOUNT_TESTNET_ADDRESS_{account['index']}",
+                    "lock_arg": f"FIBER_PR1262_ACCOUNT_LOCK_ARG_{account['index']}",
+                    "lock_hash": f"FIBER_PR1262_ACCOUNT_LOCK_HASH_{account['index']}",
+                }
+                pytest.fail(
+                    "custom PR1262 test account requires metadata env vars: "
+                    + ", ".join(missing_env_names[key] for key in missing)
+                )
+            return account
+    pytest.fail("no PR1262 account metadata found for the requested private key")
+
+
+def make_fake_ckb_cli(fake_bin):
+    fake_bin.mkdir()
+    ckb_cli = fake_bin / "ckb-cli"
+    write_executable(
+        ckb_cli,
+        f"""
+        #!/bin/sh
+        if [ "$1" = "account" ] && [ "$2" = "list" ]; then
+          cat <<EOF
+        - "#": 0
+          address:
+            mainnet: $STUB_CKB_MAINNET_ADDRESS
+            testnet: $STUB_CKB_TESTNET_ADDRESS
+          lock_arg: $STUB_CKB_LOCK_ARG
+          lock_hash: $STUB_CKB_LOCK_HASH
+          source: Local File System
+        EOF
+          exit 0
+        fi
+
+        if [ "$1" = "account" ] && [ "$2" = "export" ]; then
+          output=""
+          requested_lock_arg=""
+          while [ "$#" -gt 0 ]; do
+            if [ "$1" = "--lock-arg" ]; then
+              shift
+              requested_lock_arg="$1"
+            fi
+            if [ "$1" = "--extended-privkey-path" ]; then
+              shift
+              output="$1"
+            fi
+            shift
+          done
+          if [ "$requested_lock_arg" != "$STUB_CKB_LOCK_ARG" ]; then
+            echo "unknown lock_arg: $requested_lock_arg" >&2
+            exit 1
+          fi
+          mkdir -p "$(dirname "$output")"
+          printf '%s\\n' "$STUB_CKB_PRIVATE_KEY" > "$output"
+          exit 0
+        fi
+
+        echo "unexpected ckb-cli call: $*" >&2
+        exit 1
+        """,
+    )
+    return ckb_cli
+
+
+def patch_config_ports(config_path, p2p_port, rpc_port):
+    content = config_path.read_text()
+    content = re.sub(
+        r'listening_addr:\s*"/ip4/[^"]+/tcp/\d+"',
+        f'listening_addr: "/ip4/127.0.0.1/tcp/{p2p_port}"',
+        content,
+        count=1,
+    )
+    content = re.sub(
+        r'listening_addr:\s*"127\.0\.0\.1:\d+"',
+        f'listening_addr: "127.0.0.1:{rpc_port}"',
+        content,
+        count=1,
+    )
+    content = re.sub(
+        r'rpc_url:\s*"https://testnet\.ckbapp\.dev/"',
+        'rpc_url: "https://testnet.ckb.dev"',
+        content,
+    )
+    config_path.write_text(content)
+
+
+def run_installer(script, fnn, install_dir, fake_bin, tmp_path, private_key):
+    account = account_info_for_private_key(private_key)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(tmp_path / "home"),
+            "STUB_CKB_PRIVATE_KEY": private_key,
+            "STUB_CKB_MAINNET_ADDRESS": account["mainnet_address"],
+            "STUB_CKB_TESTNET_ADDRESS": account["testnet_address"],
+            "STUB_CKB_LOCK_ARG": account["lock_arg"],
+            "STUB_CKB_LOCK_HASH": account["lock_hash"],
+        }
+    )
+    (tmp_path / "home").mkdir(exist_ok=True)
+
+    return subprocess.run(
+        ["bash", str(script), "--local-binary", str(fnn), str(install_dir), "testnet"],
+        input=f"2\n{account['lock_arg']}\nn\n",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+
+
+def wait_log_contains(log_path, expected, label, timeout=150):
+    seen = {value: False for value in expected}
+    deadline = time.time() + timeout
+
+    with open(log_path) as log_file:
+        while time.time() < deadline:
+            line = log_file.readline()
+            if not line:
+                time.sleep(0.2)
+                continue
+
+            print(f"[{label}] {line}", end="", flush=True)
+            for value in expected:
+                if value in line:
+                    seen[value] = True
+
+            if all(seen.values()):
+                return log_path.read_text()
+
+    full_output = log_path.read_text()
+    assert all(seen.values()), full_output
+    return full_output
+
+
+def wait_startup_logs(proc, log_path, label):
+    output = wait_log_contains(
+        log_path,
+        ["Started listening tentacle"],
+        label,
+    )
+    assert proc.poll() is None, output
+    return output
+
+
+def stop_process(proc):
+    if proc.poll() is not None:
+        return
+
+    os.killpg(proc.pid, signal.SIGINT)
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=10)
+
+
+def start_node(install_dir, label):
+    env = os.environ.copy()
+    env["FIBER_SECRET_KEY_PASSWORD"] = "password0"
+    log_path = install_dir / "node.log"
+    log_file = open(log_path, "w")
+    proc = subprocess.Popen(
+        ["bash", str(install_dir / "start-node.sh")],
+        cwd=str(install_dir),
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+        preexec_fn=os.setsid,
+    )
+    proc._fiber_log_file = log_file
+    return proc, log_path, label
+
+
+def close_node_log(proc):
+    log_file = getattr(proc, "_fiber_log_file", None)
+    if log_file:
+        log_file.close()
+
+
+def wait_peer_connected(client, pubkey, timeout=120):
+    for i in range(timeout):
+        peers = client.list_peers().get("peers", [])
+        if any(peer["pubkey"] == pubkey for peer in peers):
+            print(f"Peer {pubkey} connected")
+            return
+        print(f"Waiting for peer {pubkey} to connect, try count: {i}", flush=True)
+        time.sleep(1)
+    raise TimeoutError(f"Peer {pubkey} did not connect")
+
+
+def get_channel_state(client: FiberRPCClient, pubkey: str) -> Tuple[str, Optional[str]]:
+    channels = client.list_channels({"pubkey": pubkey, "include_closed": True})[
+        "channels"
+    ]
+    if not channels:
+        return "not found", None
+    return channels[0]["state"]["state_name"], channels[0].get("channel_id")
+
+
+def get_channel_by_id(client: FiberRPCClient, pubkey: str, channel_id: str):
+    channels = client.list_channels({"pubkey": pubkey, "include_closed": True})[
+        "channels"
+    ]
+    for channel in channels:
+        if channel.get("channel_id") == channel_id:
+            return channel
+    raise AssertionError(f"channel {channel_id} not found")
+
+
+def wait_channel_states(
+    client1: FiberRPCClient,
+    client1_peer_pubkey: str,
+    client2: FiberRPCClient,
+    client2_peer_pubkey: str,
+    expected_state: str,
+    timeout: int = 600,
+) -> str:
+    poll_interval = 2
+    deadline = time.time() + timeout
+    try_count = 0
+
+    while time.time() < deadline:
+        state1, channel_id1 = get_channel_state(client1, client1_peer_pubkey)
+        state2, channel_id2 = get_channel_state(client2, client2_peer_pubkey)
+        print(
+            f"channel1 state: {state1}, channel2 state: {state2}, "
+            f"try count={try_count}",
+            flush=True,
+        )
+        if state1 == expected_state and state2 == expected_state:
+            return channel_id1 or channel_id2 or ""
+        try_count += 1
+        time.sleep(poll_interval)
+    raise TimeoutError(f"channels did not reach {expected_state}")
+
+
+def wait_payment_success(client, payment_hash, timeout=300):
+    for i in range(timeout):
+        payment = client.get_payment({"payment_hash": payment_hash})
+        status = payment["status"]
+        print(
+            f"Waiting for payment {payment_hash}: {status}, try count: {i}", flush=True
+        )
+        if status == "Success":
+            return payment
+        if status == "Failed":
+            raise AssertionError(f"payment failed: {payment}")
+        time.sleep(1)
+    raise TimeoutError("payment did not become Success")
+
+
+def get_ckb_capacity(script, rpc_url=TESTNET_CKB_RPC_URL):
+    response = RPCClient(rpc_url).get_cells_capacity(
+        {"script": script, "script_type": "lock", "script_search_mode": "exact"}
+    )
+    return int(response["capacity"], 16)
+
+
+def wait_committed_transaction(tx_hash, rpc_url=TESTNET_CKB_RPC_URL, timeout=120):
+    client = RPCClient(rpc_url)
+    for i in range(timeout):
+        response = client.get_transaction(tx_hash)
+        if response and response.get("transaction"):
+            status = response.get("tx_status", {}).get("status")
+            if status == "committed":
+                return response["transaction"]
+        print(f"Waiting for committed tx {tx_hash}, try count: {i}", flush=True)
+        time.sleep(1)
+    raise TimeoutError(f"transaction {tx_hash} did not become committed")
+
+
+def get_script_output_capacity_from_tx(tx, lock_script):
+    output_total = 0
+    for output in tx["outputs"]:
+        if output["lock"] == lock_script:
+            output_total += int(output["capacity"], 16)
+    return output_total
+
+
+def format_ckb(shannon):
+    return f"{(Decimal(shannon) / Decimal(CKB)).quantize(Decimal('0.00000001'))} CKB"
+
+
+def print_balance_change(label, before, after):
+    delta = after - before
+    print(
+        f"{label} CKB balance: before={format_ckb(before)}, "
+        f"after={format_ckb(after)}, delta={format_ckb(delta)}"
+    )
+
+
+def first_listen_addr(startup_output):
+    match = re.search(r'(/ip4/127\.0\.0\.1/tcp/\d+/p2p/[^",\s]+)', startup_output)
+    assert match, startup_output
+    return match.group(1)
+
+
+def install_node(script, fnn, tmp_path, name, private_key, p2p_port, rpc_port):
+    fake_bin = tmp_path / f"fake-bin-{name}"
+    make_fake_ckb_cli(fake_bin)
+
+    install_dir = tmp_path / name
+    install_result = run_installer(
+        script, fnn, install_dir, fake_bin, tmp_path, private_key
+    )
+
+    print(install_result.stdout)
+    assert install_result.returncode == 0, install_result.stdout
+    assert "Installation Complete" in install_result.stdout
+    assert "To start your node, run:" in install_result.stdout
+    assert (install_dir / "fnn").exists()
+    assert (install_dir / "fnn-cli").exists()
+    assert (install_dir / "config.yml").exists()
+    assert (install_dir / "start-node.sh").exists()
+
+    key_path = install_dir / "ckb" / "key"
+    assert key_path.read_text().strip() == private_key
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+    patch_config_ports(install_dir / "config.yml", p2p_port, rpc_port)
+    return install_dir
+
+
+@pytest.mark.skipif(os.name != "posix", reason="start-node.sh is a Unix script")
+class TestPR1262InstallScript:
+    def test_install_script_installs_and_starts_node(self, tmp_path):
+        script = install_sh_path()
+        fnn = local_fnn_path()
+        node_p2p_port = free_tcp_port()
+        node_rpc_port = free_tcp_port()
+
+        node_dir = install_node(
+            script,
+            fnn,
+            tmp_path,
+            "node1",
+            ACCOUNT_PRIVATE_1,
+            node_p2p_port,
+            node_rpc_port,
+        )
+
+        node = start_node(node_dir, "node1")
+        node_output = ""
+        try:
+            node_output = wait_startup_logs(*node)
+            client = FiberRPCClient(f"http://127.0.0.1:{node_rpc_port}")
+            node_info = client.node_info()
+            assert "pubkey" in node_info
+            assert "default_funding_lock_script" in node_info
+            listen_addr = first_listen_addr(node_output)
+            assert f"/tcp/{node_p2p_port}/p2p/" in listen_addr
+        finally:
+            stop_process(node[0])
+            close_node_log(node[0])
+
+        assert "Starting Fiber Network Node" in node_output
+        assert "Started listening tentacle" in node_output
+
+    @pytest.mark.skipif(
+        not run_live_channel_test(),
+        reason=(
+            f"set {RUN_LIVE_CHANNEL_ENV}=1 to run the real testnet "
+            "channel/payment/close acceptance flow"
+        ),
+    )
+    def test_install_script_installs_starts_opens_channel_and_sends_payment(
+        self, tmp_path
+    ):
+        """Manual live testnet acceptance flow.
+
+        Run with FIBER_PR1262_RUN_LIVE_CHANNEL=1. This opens a real public
+        testnet channel, sends a keysend payment, and closes the channel.
+        """
+        script = install_sh_path()
+        fnn = local_fnn_path()
+        node1_p2p_port = free_tcp_port()
+        node1_rpc_port = free_tcp_port()
+        node2_p2p_port = free_tcp_port()
+        node2_rpc_port = free_tcp_port()
+
+        node1_dir = install_node(
+            script,
+            fnn,
+            tmp_path,
+            "node1",
+            ACCOUNT_PRIVATE_1,
+            node1_p2p_port,
+            node1_rpc_port,
+        )
+        node2_dir = install_node(
+            script,
+            fnn,
+            tmp_path,
+            "node2",
+            ACCOUNT_PRIVATE_2,
+            node2_p2p_port,
+            node2_rpc_port,
+        )
+
+        node1 = start_node(node1_dir, "node1")
+        node2 = start_node(node2_dir, "node2")
+        processes = [node1[0], node2[0]]
+        node1_output = ""
+        node2_output = ""
+        node1_client = None
+        channel_id = None
+        closed_channel_id = None
+        node1_close_script = None
+        node2_close_script = None
+        try:
+            node1_output = wait_startup_logs(*node1)
+            node2_output = wait_startup_logs(*node2)
+
+            node1_client = FiberRPCClient(f"http://127.0.0.1:{node1_rpc_port}")
+            node2_client = FiberRPCClient(f"http://127.0.0.1:{node2_rpc_port}")
+            node1_info = node1_client.node_info()
+            node2_info = node2_client.node_info()
+            node1_close_script = node1_info["default_funding_lock_script"]
+            node2_close_script = node2_info["default_funding_lock_script"]
+            node2_addr = first_listen_addr(node2_output)
+            node1_balance_before_open = get_ckb_capacity(node1_close_script)
+            node2_balance_before_open = get_ckb_capacity(node2_close_script)
+            print(
+                f"node1 CKB balance before open: {format_ckb(node1_balance_before_open)}"
+            )
+            print(
+                f"node2 CKB balance before open: {format_ckb(node2_balance_before_open)}"
+            )
+
+            print(f"Connecting node1 to node2: {node2_addr}")
+            node1_client.connect_peer({"address": node2_addr})
+            wait_peer_connected(node1_client, node2_info["pubkey"])
+
+            print("Opening real testnet channel1 from node1 to node2")
+            open_result = node1_client.open_channel(
+                {
+                    "pubkey": node2_info["pubkey"],
+                    "funding_amount": hex(200 * CKB),
+                    "public": True,
+                }
+            )
+            assert "temporary_channel_id" in open_result
+            print(
+                f"channel1 temporary_channel_id: {open_result['temporary_channel_id']}"
+            )
+            channel_id = wait_channel_states(
+                node1_client,
+                node2_info["pubkey"],
+                node2_client,
+                node1_info["pubkey"],
+                "ChannelReady",
+            )
+            node2_channel_before_payment = get_channel_by_id(
+                node2_client, node1_info["pubkey"], channel_id
+            )
+            node2_local_before_payment = int(
+                node2_channel_before_payment["local_balance"], 16
+            )
+
+            print(
+                "Sending real keysend payment from node1 to node2: "
+                f"{format_ckb(PAYMENT_AMOUNT_SHANNON)}"
+            )
+            payment = node1_client.send_payment(
+                {
+                    "amount": hex(PAYMENT_AMOUNT_SHANNON),
+                    "target_pubkey": node2_info["pubkey"],
+                    "keysend": True,
+                    "udt_type_script": None,
+                }
+            )
+            payment = wait_payment_success(node1_client, payment["payment_hash"])
+            assert payment["status"] == "Success"
+            node2_channel_after_payment = get_channel_by_id(
+                node2_client, node1_info["pubkey"], channel_id
+            )
+            node2_local_after_payment = int(
+                node2_channel_after_payment["local_balance"], 16
+            )
+            print(
+                "node2 channel balance before shutdown fee: "
+                f"before={format_ckb(node2_local_before_payment)}, "
+                f"after={format_ckb(node2_local_after_payment)}, "
+                f"delta={format_ckb(node2_local_after_payment - node2_local_before_payment)}"
+            )
+            assert node2_local_after_payment == (
+                node2_local_before_payment + PAYMENT_AMOUNT_SHANNON
+            )
+
+            print("channel1 shutdown request")
+            shutdown_result = node1_client.shutdown_channel(
+                {
+                    "channel_id": channel_id,
+                    "close_script": node1_close_script,
+                    "fee_rate": "0x3FC",
+                }
+            )
+            print(f"channel1 shutdown rpc returned: {shutdown_result}")
+            closed_channel_id = wait_channel_states(
+                node1_client,
+                node2_info["pubkey"],
+                node2_client,
+                node1_info["pubkey"],
+                "Closed",
+                timeout=600,
+            )
+            closed_channel = get_channel_by_id(
+                node2_client, node1_info["pubkey"], channel_id
+            )
+            shutdown_tx_hash = closed_channel.get("shutdown_transaction_hash")
+            print(f"channel1 shutdown_transaction_hash: {shutdown_tx_hash}")
+            assert shutdown_tx_hash
+            shutdown_tx = wait_committed_transaction(shutdown_tx_hash)
+            node2_close_tx_output_capacity = get_script_output_capacity_from_tx(
+                shutdown_tx, node2_close_script
+            )
+
+            node1_balance_after_close = get_ckb_capacity(node1_close_script)
+            node2_balance_after_close = get_ckb_capacity(node2_close_script)
+            print_balance_change(
+                "node1", node1_balance_before_open, node1_balance_after_close
+            )
+            print_balance_change(
+                "node2", node2_balance_before_open, node2_balance_after_close
+            )
+            node2_wallet_delta_after_close = (
+                node2_balance_after_close - node2_balance_before_open
+            )
+            node2_close_fee_share = (
+                node2_local_after_payment
+                - node2_local_before_payment
+                - node2_wallet_delta_after_close
+            )
+            print(
+                "node2 close settlement: "
+                f"wallet delta={format_ckb(node2_wallet_delta_after_close)}, "
+                f"close tx output={format_ckb(node2_close_tx_output_capacity)}, "
+                f"inferred close fee share={format_ckb(node2_close_fee_share)}"
+            )
+            assert node2_close_tx_output_capacity > 0
+            channel_id = None
+        finally:
+            if node1_client and channel_id and node1_close_script:
+                try:
+                    print("channel1 cleanup shutdown request")
+                    shutdown_result = node1_client.shutdown_channel(
+                        {
+                            "channel_id": channel_id,
+                            "close_script": node1_close_script,
+                            "fee_rate": "0x3FC",
+                        }
+                    )
+                    print(f"channel1 cleanup shutdown rpc returned: {shutdown_result}")
+                except Exception as err:
+                    print(f"Failed to request shutdown for channel {channel_id}: {err}")
+
+            for proc in processes:
+                stop_process(proc)
+                close_node_log(proc)
+
+        assert "Starting Fiber Network Node" in node1_output
+        assert "Started listening tentacle" in node1_output
+        assert "Starting Fiber Network Node" in node2_output
+        assert "Started listening tentacle" in node2_output
+        assert closed_channel_id

--- a/test_cases/fiber/testnet/test_install_script_options.py
+++ b/test_cases/fiber/testnet/test_install_script_options.py
@@ -1,0 +1,634 @@
+"""PR #1262 installer regression: CLI options, output formatting, and re-install backup."""
+
+import os
+import pty
+import re
+import select
+import shlex
+import subprocess
+import tarfile
+import textwrap
+import time
+
+import pytest
+
+from test_install_script import (
+    ACCOUNT_1,
+    ACCOUNT_PRIVATE_1,
+    account_info_for_private_key,
+    install_sh_path,
+    make_fake_ckb_cli,
+    run_installer,
+    write_executable,
+)
+
+MAINNET_GENESIS_HASH = (
+    "0x92b197aa1fba0f63633922c61c92375c9c074a93e85963554f5499fe1450d0e5"
+)
+TESTNET_GENESIS_HASH = (
+    "0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606"
+)
+
+
+def run_help(script):
+    return subprocess.run(
+        ["bash", str(script), "--help"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+        check=False,
+    )
+
+
+def run_installer_args(script, *args, input_text=""):
+    return subprocess.run(
+        ["bash", str(script), *args],
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+        check=False,
+    )
+
+
+def installer_env(tmp_path, fake_bin, private_key=ACCOUNT_PRIVATE_1):
+    account = account_info_for_private_key(private_key)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOME": str(tmp_path / "home"),
+            "STUB_CKB_PRIVATE_KEY": private_key,
+            "STUB_CKB_MAINNET_ADDRESS": account["mainnet_address"],
+            "STUB_CKB_TESTNET_ADDRESS": account["testnet_address"],
+            "STUB_CKB_LOCK_ARG": account["lock_arg"],
+            "STUB_CKB_LOCK_HASH": account["lock_hash"],
+        }
+    )
+    (tmp_path / "home").mkdir(exist_ok=True)
+    return env
+
+
+def minimal_config(network):
+    rpc_url = (
+        "https://mainnet.ckb.dev/"
+        if network == "mainnet"
+        else "https://testnet.ckbapp.dev/"
+    )
+    return textwrap.dedent(f"""
+        fiber:
+          listening_addr: "/ip4/127.0.0.1/tcp/8228"
+          announce_listening_addr: true
+          announced_addrs: []
+          chain: {network}
+
+        rpc:
+          listening_addr: "127.0.0.1:8227"
+
+        ckb:
+          rpc_url: "{rpc_url}"
+
+        services:
+          - fiber
+          - rpc
+          - ckb
+        """).lstrip()
+
+
+def make_fake_local_fnn_bundle(tmp_path):
+    bundle_dir = tmp_path / "local-fnn"
+    bundle_dir.mkdir()
+    write_executable(
+        bundle_dir / "fnn",
+        """
+        #!/bin/sh
+        echo "fake fnn invoked: $*"
+        exit 0
+        """,
+    )
+    write_executable(
+        bundle_dir / "fnn-cli",
+        """
+        #!/bin/sh
+        echo "fake fnn-cli invoked: $*"
+        exit 0
+        """,
+    )
+    write_executable(
+        bundle_dir / "fnn-migrate",
+        """
+        #!/bin/sh
+        echo "fake fnn-migrate invoked: $*"
+        exit 0
+        """,
+    )
+    for network in ("testnet", "mainnet"):
+        config_dir = bundle_dir / "config" / network
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.yml").write_text(minimal_config(network))
+    return bundle_dir / "fnn"
+
+
+def make_fake_release_bundle(tmp_path):
+    source_dir = tmp_path / "fake-release"
+    source_dir.mkdir()
+    local_fnn = make_fake_local_fnn_bundle(source_dir)
+    bundle_path = tmp_path / "fake-fnn-release.tar.gz"
+    with tarfile.open(bundle_path, "w:gz") as archive:
+        archive.add(local_fnn.parent, arcname="fnn-release")
+    return bundle_path
+
+
+def make_fake_curl(fake_bin, response, bundle_path=None):
+    if bundle_path:
+        output_action = f'cp {shlex.quote(str(bundle_path))} "$output"'
+    else:
+        output_action = 'printf \'%s\\n\' "$response" > "$output"'
+
+    write_executable(
+        fake_bin / "curl",
+        f"""
+        #!/bin/sh
+        output=""
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = "-o" ]; then
+            shift
+            output="$1"
+          fi
+          shift
+        done
+
+        response={shlex.quote(response)}
+        if [ -n "$output" ]; then
+          {output_action}
+          exit 0
+        fi
+
+        printf '%s\\n' "$response"
+        """,
+    )
+
+
+def run_installer_pty(script, args, input_text, env, timeout=120):
+    master_fd, slave_fd = pty.openpty()
+    proc = None
+    output = bytearray()
+
+    try:
+        proc = subprocess.Popen(
+            ["bash", str(script), *args],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            env=env,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        slave_fd = None
+        os.write(master_fd, input_text.encode())
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            readable, _, _ = select.select([master_fd], [], [], 0.1)
+            if readable:
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError:
+                    chunk = b""
+                if chunk:
+                    output.extend(chunk)
+
+            if proc.poll() is not None:
+                while True:
+                    readable, _, _ = select.select([master_fd], [], [], 0)
+                    if not readable:
+                        break
+                    try:
+                        chunk = os.read(master_fd, 4096)
+                    except OSError:
+                        break
+                    if not chunk:
+                        break
+                    output.extend(chunk)
+                break
+        else:
+            proc.kill()
+            raise subprocess.TimeoutExpired(proc.args, timeout, output)
+
+        return subprocess.CompletedProcess(
+            proc.args, proc.returncode, output.decode(errors="replace")
+        )
+    finally:
+        if proc and proc.poll() is None:
+            proc.kill()
+        if slave_fd is not None:
+            os.close(slave_fd)
+        os.close(master_fd)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="install.sh is a Unix script")
+class TestPR1262InstallScriptOptions:
+    def test_help_outputs_usage(self):
+        script = install_sh_path()
+        result = run_help(script)
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Fiber Network Node (FNN) installer" in result.stdout
+        assert "Usage:" in result.stdout
+        assert "--local-binary" in result.stdout
+        assert "--mode" in result.stdout
+
+    def test_invalid_network_rejected(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        env = installer_env(tmp_path, fake_bin)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(script),
+                "--local-binary",
+                str(fnn),
+                str(tmp_path / "node"),
+                "foonet",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=60,
+            check=False,
+        )
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "Invalid network" in result.stdout
+        assert "foonet" in result.stdout
+
+    def test_invalid_mode_rejected(self, tmp_path):
+        script = install_sh_path()
+        result = run_installer_args(
+            script, "--mode", "weird", str(tmp_path / "node"), "testnet"
+        )
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "Invalid mode" in result.stdout
+
+    def test_unknown_option_rejected(self, tmp_path):
+        script = install_sh_path()
+        result = run_installer_args(script, "--definitely-not-an-option")
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "Unknown option" in result.stdout
+
+    def test_mode_requires_value(self):
+        script = install_sh_path()
+        result = run_installer_args(script, "--mode")
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "--mode requires a value" in result.stdout
+
+    def test_local_binary_requires_value(self):
+        script = install_sh_path()
+        result = run_installer_args(script, "--local-binary")
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "--local-binary requires a path" in result.stdout
+
+    def test_missing_local_binary_rejected(self, tmp_path):
+        script = install_sh_path()
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        env = installer_env(tmp_path, fake_bin)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(script),
+                "--local-binary",
+                str(tmp_path / "missing-fnn"),
+                str(tmp_path / "node"),
+                "testnet",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=60,
+            check=False,
+        )
+        print(result.stdout)
+        assert result.returncode != 0
+        assert "Local fnn binary not found" in result.stdout
+
+    def test_bootstrap_mode_installs_default_testnet_bundle(self, tmp_path):
+        script = install_sh_path()
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        release_bundle = make_fake_release_bundle(tmp_path)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+            bundle_path=release_bundle,
+        )
+        env = installer_env(tmp_path, fake_bin)
+
+        result = subprocess.run(
+            ["bash", str(script), "--mode", "bootstrap"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+        print(result.stdout)
+        install_dir = tmp_path / "home" / ".fiber"
+        assert result.returncode == 0, result.stdout
+        assert "Running in non-interactive mode with defaults" in result.stdout
+        assert "Network: testnet" in result.stdout
+        assert (install_dir / ".fiber-network").read_text().strip() == "testnet"
+        assert (install_dir / "tools" / "install" / "install.sh").exists()
+        assert (install_dir / "fiber").is_dir()
+        assert (install_dir / "fnn").exists()
+        assert (install_dir / "fnn-cli").exists()
+        assert (install_dir / "fnn-migrate").exists()
+        config = (install_dir / "config.yml").read_text()
+        assert "chain: testnet" in config
+
+    def test_install_output_has_no_literal_ansi_escape(self, tmp_path):
+        """Regression for ANSI literal `\\033[0m` text in formatted sections."""
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        result = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Installation Complete" in result.stdout
+        # The installer must not leak literal escape sequences in its output.
+        assert "\\033[" not in result.stdout, (
+            "literal ANSI escape sequence found in installer output:\n" + result.stdout
+        )
+        assert "\\e[" not in result.stdout
+
+    def test_existing_install_dir_is_backed_up(self, tmp_path):
+        """Re-running the installer on a non-empty dir should back it up
+        (non-interactive path) and produce a fresh install."""
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        first = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        assert first.returncode == 0, first.stdout
+        first_key = (install_dir / "ckb" / "key").read_text().strip()
+
+        second = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        print(second.stdout)
+        assert second.returncode == 0, second.stdout
+        assert "Backed up existing install path" in second.stdout
+
+        backups = sorted(tmp_path.glob("node.backup-*"))
+        assert backups, f"expected backup dir, got: {list(tmp_path.iterdir())}"
+        assert (backups[-1] / "ckb" / "key").exists()
+
+        # Fresh install should still be valid.
+        assert (install_dir / "fnn").exists()
+        assert (install_dir / "start-node.sh").exists()
+        assert (install_dir / "config.yml").exists()
+        assert (install_dir / "ckb" / "key").read_text().strip() == first_key
+
+    def test_existing_install_dir_preserves_ckb_cli_after_backup(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        install_dir = tmp_path / "node"
+        install_dir.mkdir()
+        write_executable(
+            install_dir / "ckb-cli",
+            """
+            #!/bin/sh
+            if [ "$1" = "account" ] && [ "$2" = "list" ]; then
+              cat <<EOF
+            - "#": 0
+              address:
+                mainnet: $STUB_CKB_MAINNET_ADDRESS
+                testnet: $STUB_CKB_TESTNET_ADDRESS
+              lock_arg: $STUB_CKB_LOCK_ARG
+              lock_hash: $STUB_CKB_LOCK_HASH
+              source: Local File System
+            EOF
+              exit 0
+            fi
+
+            if [ "$1" = "account" ] && [ "$2" = "export" ]; then
+              output=""
+              while [ "$#" -gt 0 ]; do
+                if [ "$1" = "--extended-privkey-path" ]; then
+                  shift
+                  output="$1"
+                fi
+                shift
+              done
+              mkdir -p "$(dirname "$output")"
+              printf '%s\\n' "$STUB_CKB_PRIVATE_KEY" > "$output"
+              exit 0
+            fi
+
+            echo "unexpected ckb-cli call: $*" >&2
+            exit 1
+            """,
+        )
+        (install_dir / "old-data").write_text("old")
+
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir()
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        env = installer_env(tmp_path, fake_bin)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(script),
+                "--local-binary",
+                str(fnn),
+                str(install_dir),
+                "testnet",
+            ],
+            input=f"2\n{ACCOUNT_1['lock_arg']}\nn\n",
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=120,
+            check=False,
+        )
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Backed up existing install path" in result.stdout
+        assert "Preserved existing ckb-cli" in result.stdout
+        assert (install_dir / "ckb-cli").exists()
+        assert (install_dir / "ckb" / "key").read_text().strip() == ACCOUNT_PRIVATE_1
+
+    def test_generated_start_node_script_uses_install_dir(self, tmp_path):
+        """start-node.sh should resolve INSTALL_DIR relative to itself
+        (so users can re-run it from any cwd after install)."""
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        result = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        assert result.returncode == 0, result.stdout
+
+        start_script = (install_dir / "start-node.sh").read_text()
+        assert 'INSTALL_DIR="$(cd "$(dirname "$0")" && pwd)"' in start_script
+        assert "FIBER_SECRET_KEY_PASSWORD" in start_script
+        assert "./fnn -c config.yml" in start_script
+        # Network marker is written/checked so users can't mix networks by mistake.
+        assert ".fiber-network" in start_script
+        # Sanity: no unresolved bash variable from the heredoc escape.
+        assert not re.search(r"\$\{?NETWORK_MARKER_FILE_NAME\}?", start_script)
+
+    def test_generated_start_node_rejects_network_marker_mismatch(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{TESTNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        result = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        assert result.returncode == 0, result.stdout
+        assert (install_dir / ".fiber-network").read_text().strip() == "testnet"
+
+        config_path = install_dir / "config.yml"
+        config_path.write_text(
+            config_path.read_text().replace("chain: testnet", "chain: mainnet")
+        )
+
+        env = os.environ.copy()
+        env["FIBER_SECRET_KEY_PASSWORD"] = "password0"
+        start = subprocess.run(
+            ["bash", str(install_dir / "start-node.sh")],
+            cwd=str(tmp_path),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            timeout=30,
+            check=False,
+        )
+        print(start.stdout)
+        assert start.returncode != 0
+        assert "marked for testnet" in start.stdout
+        assert "config.yml is set to mainnet" in start.stdout
+
+    def test_ckb_rpc_preflight_warns_on_wrong_network_genesis(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{MAINNET_GENESIS_HASH}"}}',
+        )
+        install_dir = tmp_path / "node"
+
+        result = run_installer(
+            script, fnn, install_dir, fake_bin, tmp_path, ACCOUNT_PRIVATE_1
+        )
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Skipping automatic startup" in result.stdout
+        assert "does not appear to be a testnet node" in result.stdout
+        assert "Update ckb.rpc_url" in result.stdout
+
+    def test_mainnet_public_node_configures_announced_fields(self, tmp_path):
+        script = install_sh_path()
+        fnn = make_fake_local_fnn_bundle(tmp_path)
+        fake_bin = tmp_path / "fake-bin"
+        make_fake_ckb_cli(fake_bin)
+        make_fake_curl(
+            fake_bin,
+            f'{{"id":2,"jsonrpc":"2.0","result":"{MAINNET_GENESIS_HASH}"}}',
+        )
+        env = installer_env(tmp_path, fake_bin)
+        install_dir = tmp_path / "node"
+        ckb_rpc_url = "http://127.0.0.1:8114/"
+        announced_addr = "/ip4/203.0.113.10/tcp/8228"
+        announced_name = "Node Name"
+
+        result = run_installer_pty(
+            script,
+            [
+                "--local-binary",
+                str(fnn),
+                str(install_dir),
+                "mainnet",
+            ],
+            (
+                f"{ckb_rpc_url}\n"
+                f"y\n"
+                f"{announced_addr}\n"
+                f"{announced_name}\n"
+                f"2\n"
+                f"{ACCOUNT_1['lock_arg']}\n"
+                f"n\n"
+            ),
+            env,
+        )
+        print(result.stdout)
+        assert result.returncode == 0, result.stdout
+        assert "Configured this mainnet node as a public Fiber node" in result.stdout
+
+        config = (install_dir / "config.yml").read_text()
+        assert f'rpc_url: "{ckb_rpc_url}"' in config
+        assert "chain: mainnet" in config
+        assert "auto_announce_node: true" in config
+        assert "announce_listening_addr: true" in config
+        assert f'    - "{announced_addr}"' in config
+        assert f'announced_node_name: "{announced_name}"' in config


### PR DESCRIPTION
## Summary
- add v0.9.0 migration regression tests
- add PR1262 installer regression and testnet smoke coverage
- run migration tests in the fiber CI workflow

## Verification
- `black --check .`
- `pytest --collect-only -q test_cases/fiber/devnet/migration test_cases/fiber/testnet/test_install_script.py test_cases/fiber/testnet/test_install_script_options.py`
