### PR TITLE
[codex] Add Discord notifications for network CI

### DIFF
--- a/.github/workflows/fiber-mainnet.yml
+++ b/.github/workflows/fiber-mainnet.yml
@@ -69,3 +69,28 @@ jobs:
       with:
         name: jfoa-build-reports-${{ runner.os }}
         path: ./report
+
+  notify-discord:
+    runs-on: ubuntu-22.04
+    needs: build
+    if: always()
+    steps:
+      - name: Notify Discord on success
+        if: needs.build.result == 'success'
+        continue-on-error: true
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          title: "Fiber Mainnet Test Succeeded"
+          description: "Fiber mainnet test succeeded for fiber branch ${{ github.event.inputs.GitBranch || 'develop' }}. Triggered by ${{ github.actor }}. Check run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          color: 0x00ff00
+
+      - name: Notify Discord on failure
+        if: needs.build.result != 'success'
+        continue-on-error: true
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          title: "Fiber Mainnet Test Failed"
+          description: "Fiber mainnet test finished with ${{ needs.build.result }} for fiber branch ${{ github.event.inputs.GitBranch || 'develop' }}. Check run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          color: 0xff0000

--- a/.github/workflows/fiber-testnet.yml
+++ b/.github/workflows/fiber-testnet.yml
@@ -66,3 +66,28 @@ jobs:
       with:
         name: jfoa-build-reports-${{ runner.os }}
         path: ./report
+
+  notify-discord:
+    runs-on: ubuntu-22.04
+    needs: build
+    if: always()
+    steps:
+      - name: Notify Discord on success
+        if: needs.build.result == 'success'
+        continue-on-error: true
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          title: "Fiber Testnet Test Succeeded"
+          description: "Fiber testnet test succeeded for fiber branch ${{ github.event.inputs.GitBranch || 'develop' }}. Triggered by ${{ github.actor }}. Check run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          color: 0x00ff00
+
+      - name: Notify Discord on failure
+        if: needs.build.result != 'success'
+        continue-on-error: true
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          title: "Fiber Testnet Test Failed"
+          description: "Fiber testnet test finished with ${{ needs.build.result }} for fiber branch ${{ github.event.inputs.GitBranch || 'develop' }}. Check run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          color: 0xff0000


### PR DESCRIPTION
## Summary

- Add a notify-discord job to the mainnet CI workflow.
- Add the same Discord notification job to the testnet CI workflow.
- Use sarisia/actions-status-discord@v1 with the DISCORD_WEBHOOK repository secret.

## Validation

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: YAML parsed successfully" }' .github/workflows/fiber-mainnet.yml .github/workflows/fiber-testnet.yml
- git diff --check -- .github/workflows/fiber-mainnet.yml .github/workflows/fiber-testnet.yml
