### PR TITLE
[codex] Mention user on failed Discord CI notifications

### DIFF
--- a/.github/workflows/fiber-mainnet.yml
+++ b/.github/workflows/fiber-mainnet.yml
@@ -91,6 +91,7 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          content: "<@802020984097734656>"
           title: "Fiber Mainnet Test Failed"
           description: "Fiber mainnet test finished with ${{ needs.build.result }} for fiber branch ${{ github.event.inputs.GitBranch || 'develop' }}. Check run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
           color: 0xff0000

--- a/.github/workflows/fiber-testnet.yml
+++ b/.github/workflows/fiber-testnet.yml
@@ -88,6 +88,7 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          content: "<@802020984097734656>"
           title: "Fiber Testnet Test Failed"
           description: "Fiber testnet test finished with ${{ needs.build.result }} for fiber branch ${{ github.event.inputs.GitBranch || 'develop' }}. Check run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
           color: 0xff0000


### PR DESCRIPTION
## Summary

- Add a Discord user mention to failed mainnet CI notifications.
- Add the same mention to failed testnet CI notifications.
- Keep success notifications unchanged.

## Validation

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: YAML parsed successfully" }' .github/workflows/fiber-mainnet.yml .github/workflows/fiber-testnet.yml
- git diff --check origin/v0.9.0...HEAD -- .github/workflows/fiber-mainnet.yml .github/workflows/fiber-testnet.yml
