### PR TITLE
[codex] Guard stable stress test against stalled payments

### DIFF
--- a/download_fiber.py
+++ b/download_fiber.py
@@ -18,7 +18,7 @@ versions = [
     "0.7.1",
     "0.8.0",
     "0.8.1",
-    "0.9.0-rc4",
+    "0.9.0-rc5",
 ]
 
 DOWNLOAD_DIR = "download/fiber"

--- a/framework/fiber_rpc.py
+++ b/framework/fiber_rpc.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import requests
@@ -11,12 +12,22 @@ LOGGER = logging.getLogger(__name__)
 
 class FiberRPCClient:
     def __init__(
-        self, url, other_params={}, try_count=200, retryable_error_messages=None
+        self,
+        url,
+        other_params={},
+        try_count=200,
+        retryable_error_messages=None,
+        timeout=None,
     ):
         self.url = url
         self.other_params = other_params
         self.try_count = try_count
         self.retryable_error_messages = retryable_error_messages or []
+        self.timeout = (
+            timeout
+            if timeout is not None
+            else float(os.environ.get("FIBER_RPC_TIMEOUT", "60"))
+        )
 
     def send_btc(self, btc_pay_req):
         return self.call("send_btc", [btc_pay_req])
@@ -260,7 +271,10 @@ class FiberRPCClient:
         for i in range(self.try_count):
             try:
                 response = requests.post(
-                    self.url, data=json.dumps(data), headers=headers
+                    self.url,
+                    data=json.dumps(data),
+                    headers=headers,
+                    timeout=self.timeout,
                 ).json()
                 LOGGER.debug(
                     "response:\n{response}".format(response=json.dumps(response))
@@ -277,6 +291,10 @@ class FiberRPCClient:
                     raise Exception(f"Error: {error_message}")
 
                 return response.get("result", None)
+            except requests.exceptions.Timeout as e:
+                raise Exception(
+                    f"RPC request timed out: method={method}, url={self.url}, timeout={self.timeout}s"
+                ) from e
             except requests.exceptions.ConnectionError as e:
                 LOGGER.debug(e)
                 LOGGER.debug("request too quickly, wait 2s")

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,6 +1,6 @@
 set -ex
 
-DEFAULT_FIBER_BRANCH="v0.9.0-rc4"
+DEFAULT_FIBER_BRANCH="v0.9.0-rc5"
 DEFAULT_FIBER_URL="https://github.com/nervosnetwork/fiber.git"
 
 GitFIBERBranch="${GitBranch:-$DEFAULT_FIBER_BRANCH}"

--- a/test_cases/fiber/devnet/stable/test_stable.py
+++ b/test_cases/fiber/devnet/stable/test_stable.py
@@ -8,6 +8,43 @@ from framework.config import DEFAULT_MIN_DEPOSIT_CKB
 from framework.test_wasm_fiber import WasmFiber
 
 
+def _collect_stable_futures(
+    pending_set,
+    completed_tasks,
+    failed_tasks,
+    tasks_submitted,
+    start_time,
+    logger,
+    times,
+    completed_counts,
+    wait_all=False,
+    timeout=0,
+):
+    if not pending_set:
+        return pending_set, completed_tasks, failed_tasks, 0
+    done, pending_set = concurrent.futures.wait(
+        pending_set,
+        timeout=timeout,
+        return_when=(
+            concurrent.futures.ALL_COMPLETED
+            if wait_all
+            else concurrent.futures.FIRST_COMPLETED
+        ),
+    )
+    for future in done:
+        completed_tasks += 1
+        try:
+            future.result()
+            logger.debug(f"Task {completed_tasks}/{tasks_submitted} completed")
+        except Exception as e:
+            failed_tasks += 1
+            logger.error(f"Task {completed_tasks}/{tasks_submitted} failed: {e}")
+        elapsed_time = time.time() - start_time
+        times.append(elapsed_time)
+        completed_counts.append(completed_tasks)
+    return pending_set, completed_tasks, failed_tasks, len(done)
+
+
 class TestStableStress(FiberTest):
     fnn_log_level = "info"
 
@@ -114,50 +151,46 @@ class TestStableStress(FiberTest):
         start_time = time.time()
         times = []
         completed_counts = []
-        max_inflight = 25
+        max_inflight = 16
         completed_tasks = 0
-
-        def _collect(pending_set, wait_all=False):
-            """Collect completed futures from pending set."""
-            nonlocal completed_tasks
-            if not pending_set:
-                return pending_set
-            done, pending_set = concurrent.futures.wait(
-                pending_set,
-                timeout=0 if not wait_all else 20,
-                return_when=(
-                    concurrent.futures.ALL_COMPLETED
-                    if wait_all
-                    else concurrent.futures.FIRST_COMPLETED
-                ),
-            )
-            for future in done:
-                completed_tasks += 1
-                try:
-                    future.result()
-                    self.logger.debug(
-                        f"Task {completed_tasks}/{tasks_submitted} completed"
-                    )
-                except Exception as e:
-                    self.logger.error(
-                        f"Task {completed_tasks}/{tasks_submitted} failed: {e}"
-                    )
-                elapsed_time = time.time() - start_time
-                times.append(elapsed_time)
-                completed_counts.append(completed_tasks)
-            return pending_set
+        failed_tasks = 0
+        last_progress_time = start_time
+        no_progress_timeout = int(os.environ.get("STABLE_NO_PROGRESS_TIMEOUT", 300))
+        final_drain_timeout = int(os.environ.get("STABLE_FINAL_DRAIN_TIMEOUT", 300))
 
         tps_interval = 10  # print TPS every 10 seconds
         last_tps_time = start_time
         last_tps_completed = 0
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
-            pending = set()
-
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=16)
+        pending = set()
+        try:
             while time.time() - start_time < duration_seconds:
                 # Drain completed futures to keep in-flight count bounded
                 while len(pending) >= max_inflight:
-                    pending = _collect(pending)
+                    (
+                        pending,
+                        completed_tasks,
+                        failed_tasks,
+                        finished_count,
+                    ) = _collect_stable_futures(
+                        pending,
+                        completed_tasks,
+                        failed_tasks,
+                        tasks_submitted,
+                        start_time,
+                        self.logger,
+                        times,
+                        completed_counts,
+                        timeout=1,
+                    )
+                    if finished_count > 0:
+                        last_progress_time = time.time()
+                    elif time.time() - last_progress_time >= no_progress_timeout:
+                        raise TimeoutError(
+                            f"stable test stuck: {len(pending)} tasks pending, "
+                            f"no task completed for {no_progress_timeout}s"
+                        )
 
                 # Submit one round of payment tasks (8 tasks)
                 pending.add(
@@ -217,10 +250,30 @@ class TestStableStress(FiberTest):
             self.logger.info(
                 f"Duration {duration_seconds}s reached. Waiting for {len(pending)} remaining tasks..."
             )
-            pending = _collect(pending, wait_all=True)
+            drain_deadline = time.time() + final_drain_timeout
+            while pending and time.time() < drain_deadline:
+                (
+                    pending,
+                    completed_tasks,
+                    failed_tasks,
+                    finished_count,
+                ) = _collect_stable_futures(
+                    pending,
+                    completed_tasks,
+                    failed_tasks,
+                    tasks_submitted,
+                    start_time,
+                    self.logger,
+                    times,
+                    completed_counts,
+                    timeout=1,
+                )
+                if finished_count > 0:
+                    last_progress_time = time.time()
             if pending:
-                self.logger.warning(
-                    f"Timeout: {len(pending)} tasks still pending, skipping"
+                raise TimeoutError(
+                    f"stable test drain timed out: {len(pending)} tasks still pending "
+                    f"after {final_drain_timeout}s"
                 )
 
             total_time = time.time() - start_time
@@ -230,8 +283,12 @@ class TestStableStress(FiberTest):
             )
 
             self.logger.info(
-                f"finished, duration: {duration_seconds}s, tasks: {tasks_submitted}"
+                f"finished, duration: {duration_seconds}s, tasks: {tasks_submitted}, failed: {failed_tasks}"
             )
+        finally:
+            for future in pending:
+                future.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
         self.get_fibers_balance_message()
         for fiber in self.fibers:
             message = self.get_fiber_balance(fiber)

--- a/test_cases/framework/test_fiber_rpc_timeout.py
+++ b/test_cases/framework/test_fiber_rpc_timeout.py
@@ -1,0 +1,24 @@
+import pytest
+import requests
+
+from framework.fiber_rpc import FiberRPCClient
+
+
+def test_rpc_timeout_fails_with_method_and_url(monkeypatch):
+    calls = []
+
+    def fake_post(url, data, headers, timeout):
+        calls.append((url, timeout))
+        raise requests.exceptions.Timeout("slow rpc")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    client = FiberRPCClient("http://127.0.0.1:8228", try_count=3, timeout=2)
+
+    with pytest.raises(Exception) as exc_info:
+        client.call("send_payment", [{}])
+
+    assert "RPC request timed out" in str(exc_info.value)
+    assert "method=send_payment" in str(exc_info.value)
+    assert "url=http://127.0.0.1:8228" in str(exc_info.value)
+    assert calls == [("http://127.0.0.1:8228", 2)]

--- a/test_cases/framework/test_stable_harness.py
+++ b/test_cases/framework/test_stable_harness.py
@@ -1,0 +1,45 @@
+import concurrent.futures
+
+from test_cases.fiber.devnet.stable import test_stable
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.errors = []
+
+    def debug(self, message):
+        pass
+
+    def error(self, message):
+        self.errors.append(message)
+
+
+def test_collect_stable_futures_records_payment_failures_without_raising():
+    logger = RecordingLogger()
+    times = []
+    completed_counts = []
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        pending = {
+            executor.submit(lambda: "ok"),
+            executor.submit(lambda: (_ for _ in ()).throw(Exception("payment failed"))),
+        }
+        concurrent.futures.wait(pending)
+
+    pending, completed, failed, finished = test_stable._collect_stable_futures(
+        pending,
+        completed_tasks=0,
+        failed_tasks=0,
+        tasks_submitted=2,
+        start_time=0,
+        logger=logger,
+        times=times,
+        completed_counts=completed_counts,
+    )
+
+    assert pending == set()
+    assert completed == 2
+    assert failed == 1
+    assert finished == 2
+    assert len(logger.errors) == 1
+    assert "payment failed" in logger.errors[0]


### PR DESCRIPTION
## Summary

- Add a configurable JSON-RPC request timeout to `FiberRPCClient` so stalled FNN/WASM RPC calls do not block Python forever.
- Refactor the stable stress future collection path so individual payment failures are counted and logged, while the harness fails only when pending work makes no progress or cannot drain.
- Add lightweight framework tests for RPC timeout behavior and stable future collection semantics.

## Root Cause

The stable stress test allowed normal payment exceptions, but a hung RPC call could keep worker futures pending forever. Once the pending set reached the in-flight cap, the main loop waited for capacity without rechecking the test duration, so CI could sit silently until the GitHub Actions 6h cancellation.

## Validation

- `.venv/bin/pytest test_cases/framework/test_fiber_rpc_timeout.py test_cases/framework/test_stable_harness.py -q`
- `.venv/bin/python -m py_compile framework/fiber_rpc.py test_cases/fiber/devnet/stable/test_stable.py test_cases/framework/test_fiber_rpc_timeout.py test_cases/framework/test_stable_harness.py`
- `git diff --check`
