### PR TITLE
Stabilize Fiber rc7 integration regressions

### DIFF
--- a/.github/workflows/fiber.yml
+++ b/.github/workflows/fiber.yml
@@ -18,7 +18,7 @@ on:
         default: 'https://github.com/nervosnetwork/fiber.git'
       GitBranch:
         description: 'fiber -git branch'
-        default: 'develop'
+        default: 'v0.9.0-rc7'
   schedule:
     - cron: '0 0 */7 * *'
 

--- a/framework/basic_fiber.py
+++ b/framework/basic_fiber.py
@@ -294,10 +294,19 @@ class FiberTest(CkbTest):
                 continue
             idx = 0
             if channel_id is not None:
+                found_channel = False
                 for i in range(len(channels["channels"])):
                     print("channel_id:", channel_id)
                     if channels["channels"][i]["channel_id"] == channel_id:
                         idx = i
+                        found_channel = True
+                        break
+                if not found_channel:
+                    self.logger.debug(
+                        f"Waiting for channel id {channel_id}, current channels: {channels['channels']}"
+                    )
+                    time.sleep(1)
+                    continue
             if type(expected_state) == str:
                 if channels["channels"][idx]["state"]["state_name"] == expected_state:
                     self.logger.debug(
@@ -322,6 +331,30 @@ class FiberTest(CkbTest):
             f"Channel did not reach state {expected_state} within timeout period."
         )
 
+    def wait_for_new_channel_state(
+        self,
+        client,
+        pubkey,
+        expected_state,
+        existing_channel_ids,
+        timeout=180,
+    ):
+        for _ in range(timeout):
+            channels = client.list_channels({"pubkey": pubkey})
+            for channel in channels["channels"]:
+                channel_id = channel["channel_id"]
+                if channel_id in existing_channel_ids:
+                    continue
+                if channel["state"]["state_name"] == expected_state:
+                    time.sleep(1)
+                    return channel_id
+            time.sleep(1)
+        channels = client.list_channels({"pubkey": pubkey})
+        raise TimeoutError(
+            f"New channel did not reach state {expected_state} within timeout period. "
+            f"existing={existing_channel_ids}, current={channels['channels']}"
+        )
+
     def get_account_udt_script(self, account_private_key):
         account1 = self.Ckb_cli.util_key_info_by_private_key(account_private_key)
         return {
@@ -342,7 +375,12 @@ class FiberTest(CkbTest):
         other_config={},
     ):
         fiber1.connect_peer(fiber2)
-        time.sleep(1)
+        existing_channel_ids = {
+            channel["channel_id"]
+            for channel in fiber1.get_client().list_channels(
+                {"pubkey": fiber2.get_pubkey()}
+            )["channels"]
+        }
         if fiber1_balance <= int(
             fiber2.get_client().node_info()[
                 "open_channel_auto_accept_min_ckb_funding_amount"
@@ -365,11 +403,13 @@ class FiberTest(CkbTest):
                     "tlc_fee_proportional_millionths": hex(fiber2_fee),
                 }
             )
-            time.sleep(1)
-            self.wait_for_channel_state(
-                fiber1.get_client(), fiber2.get_pubkey(), "ChannelReady"
+            channel_id = self.wait_for_new_channel_state(
+                fiber1.get_client(),
+                fiber2.get_pubkey(),
+                "ChannelReady",
+                existing_channel_ids,
             )
-            return
+            return channel_id
         open_channel_config = {
             "pubkey": fiber2.get_pubkey(),
             "funding_amount": hex(
@@ -381,8 +421,11 @@ class FiberTest(CkbTest):
         }
         open_channel_config.update(other_config)
         fiber1.get_client().open_channel(open_channel_config)
-        self.wait_for_channel_state(
-            fiber1.get_client(), fiber2.get_pubkey(), "ChannelReady"
+        channel_id = self.wait_for_new_channel_state(
+            fiber1.get_client(),
+            fiber2.get_pubkey(),
+            "ChannelReady",
+            existing_channel_ids,
         )
         channels = fiber1.get_client().list_channels({"pubkey": fiber2.get_pubkey()})
         # payment = fiber1.get_client().send_payment(
@@ -405,6 +448,7 @@ class FiberTest(CkbTest):
         # channels = fiber1.get_client().list_channels({"pubkey": fiber2.get_pubkey()})
         # assert channels["channels"][0]["local_balance"] == hex(fiber1_balance)
         # assert channels["channels"][0]["remote_balance"] == hex(fiber2_balance)
+        return channel_id
 
     def send_invoice_payment(
         self,

--- a/framework/fiber_rpc.py
+++ b/framework/fiber_rpc.py
@@ -22,7 +22,12 @@ class FiberRPCClient:
         self.url = url
         self.other_params = other_params
         self.try_count = try_count
-        self.retryable_error_messages = retryable_error_messages or []
+        default_retryable_error_messages = [
+            "waiting for peer to send Init message",
+        ]
+        self.retryable_error_messages = default_retryable_error_messages + (
+            retryable_error_messages or []
+        )
         self.timeout = (
             timeout
             if timeout is not None

--- a/framework/fiber_rpc.py
+++ b/framework/fiber_rpc.py
@@ -273,6 +273,7 @@ class FiberRPCClient:
                 url=self.url, data=json.dumps(data, indent=4)
             )
         )
+        last_retryable_error = None
         for i in range(self.try_count):
             try:
                 response = requests.post(
@@ -290,6 +291,7 @@ class FiberRPCClient:
                         message in error_message
                         for message in self.retryable_error_messages
                     ):
+                        last_retryable_error = error_message
                         LOGGER.debug("retryable rpc error: %s", error_message)
                         time.sleep(2)
                         continue
@@ -305,4 +307,6 @@ class FiberRPCClient:
                 LOGGER.debug("request too quickly, wait 2s")
                 time.sleep(2)
                 continue
+        if last_retryable_error is not None:
+            raise Exception(f"Error: {last_retryable_error}")
         raise Exception("request time out")

--- a/framework/test_fiber.py
+++ b/framework/test_fiber.py
@@ -291,13 +291,12 @@ class Fiber:
         )
 
     def connect_peer(self, node):
-        address = (
-            node.get_client()
-            .node_info()["addresses"][0]
-            .replace("0。0.0.0", "127.0.0.1")
-        )
+        node_info = node.get_client().node_info()
+        address = node_info["addresses"][0].replace("0。0.0.0", "127.0.0.1")
         result = self.client.connect_peer({"address": address})
-        remote_pubkey = node.get_pubkey()
+        remote_pubkey = node_info.get("pubkey")
+        if remote_pubkey is None:
+            return result
         deadline = time.time() + 30
         while time.time() < deadline:
             peers = self.client.list_peers().get("peers") or []

--- a/framework/test_fiber.py
+++ b/framework/test_fiber.py
@@ -296,4 +296,12 @@ class Fiber:
             .node_info()["addresses"][0]
             .replace("0。0.0.0", "127.0.0.1")
         )
-        return self.client.connect_peer({"address": address})
+        result = self.client.connect_peer({"address": address})
+        remote_pubkey = node.get_pubkey()
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            peers = self.client.list_peers().get("peers") or []
+            if any(peer.get("pubkey") == remote_pubkey for peer in peers):
+                return result
+            time.sleep(0.5)
+        return result

--- a/framework/util.py
+++ b/framework/util.py
@@ -3,7 +3,6 @@ import subprocess
 import time
 import json
 import toml
-import re
 import struct
 
 import hashlib
@@ -130,14 +129,7 @@ def run_command(cmd, check_exit_code=True, env=None):
 
 
 def get_project_root():
-    current_path = os.path.dirname(os.path.abspath(__file__))
-    pattern = r"(.*fiber-py-integration-test)"
-    matches = re.findall(pattern, current_path)
-    if matches:
-        root_dir = max(matches, key=len)
-        return root_dir
-    else:
-        raise Exception("not found fiber-py-integration-test dir")
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def read_toml_file(file_path):

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,6 +1,6 @@
 set -ex
 
-DEFAULT_FIBER_BRANCH="develop"
+DEFAULT_FIBER_BRANCH="v0.9.0-rc7"
 DEFAULT_FIBER_URL="https://github.com/nervosnetwork/fiber.git"
 
 GitFIBERBranch="${GitBranch:-$DEFAULT_FIBER_BRANCH}"

--- a/test_cases/fiber/devnet/migration/_helpers.py
+++ b/test_cases/fiber/devnet/migration/_helpers.py
@@ -153,7 +153,7 @@ def open_v070_channel(opener, balance):
     )
 
 
-def send_invoice_payment_with_timeout(test_case, fiber1, fiber2, amount, timeout=45):
+def send_invoice_payment_with_timeout(test_case, fiber1, fiber2, amount, timeout=60):
     invoice = rpc_call_with_timeout(
         fiber2,
         "new_invoice",
@@ -199,13 +199,13 @@ def send_invoice_payment_with_timeout(test_case, fiber1, fiber2, amount, timeout
     )
 
 
-def send_invoice_payment_with_retry(test_case, fiber1, fiber2, amount, timeout=60):
+def send_invoice_payment_with_retry(test_case, fiber1, fiber2, amount, timeout=120):
     deadline = time.time() + timeout
     last_error = None
     while time.time() < deadline:
         try:
             return send_invoice_payment_with_timeout(
-                test_case, fiber1, fiber2, amount, timeout=15
+                test_case, fiber1, fiber2, amount, timeout=30
             )
         except Exception as e:
             last_error = e

--- a/test_cases/fiber/devnet/migration/test_large_u128_channel_constraints.py
+++ b/test_cases/fiber/devnet/migration/test_large_u128_channel_constraints.py
@@ -18,7 +18,7 @@ from ._helpers import (
     fiber_bin_exists,
     list_channels_with_timeout,
     MigrationFiberTest,
-    send_invoice_payment_with_timeout,
+    send_invoice_payment_with_retry,
     start_with_confirm,
     wait_log_matches,
     wait_peer_connected,
@@ -75,6 +75,8 @@ class TestLargeU128ChannelConstraints(MigrationFiberTest):
         old_b.fiber_config_enum = FiberConfigPath.CURRENT_DEV
         start_with_confirm(old_a, confirm="y")
         start_with_confirm(old_b, confirm="y")
+        old_a.connect_peer(old_b)
+        wait_peer_connected(old_a, timeout=30)
 
         wait_log_matches(
             old_a, r"Migrating to {}".format(LATEST_DB_VERSION_AFTER_PR1323)
@@ -85,5 +87,5 @@ class TestLargeU128ChannelConstraints(MigrationFiberTest):
         assert len(chans) == old_channel_count, "channel must survive migration"
         assert all(c["state"]["state_name"] == "ChannelReady" for c in chans), chans
 
-        send_invoice_payment_with_timeout(self, old_a, old_b, 1)
-        send_invoice_payment_with_timeout(self, old_b, old_a, 1)
+        send_invoice_payment_with_retry(self, old_a, old_b, 1)
+        send_invoice_payment_with_retry(self, old_b, old_a, 1)

--- a/test_cases/fiber/devnet/proxy/test_pr1228_tor.py
+++ b/test_cases/fiber/devnet/proxy/test_pr1228_tor.py
@@ -191,6 +191,32 @@ class TestPR1228TorOnion(FiberTest):
             f"peer {remote_pubkey} not listed before timeout ({timeout}s)"
         )
 
+    def _connect_peer_until_visible(
+        self,
+        dialer,
+        listener,
+        address: str,
+        timeout: float = 300.0,
+    ):
+        deadline = time.time() + timeout
+        last_error = None
+        while time.time() < deadline:
+            try:
+                dialer.get_client().connect_peer({"address": address})
+            except Exception as e:
+                last_error = e
+            dialer_peers = dialer.get_client().list_peers().get("peers") or []
+            listener_peers = listener.get_client().list_peers().get("peers") or []
+            if any(
+                p.get("pubkey") == listener.get_pubkey() for p in dialer_peers
+            ) and any(p.get("pubkey") == dialer.get_pubkey() for p in listener_peers):
+                return
+            time.sleep(5.0)
+        raise AssertionError(
+            "peer connection via onion was not visible on both nodes before "
+            f"timeout ({timeout}s), last_error={last_error}"
+        )
+
     def _wait_onion_multiaddr(self, client, timeout: float = 180.0) -> str:
         deadline = time.time() + timeout
         while time.time() < deadline:
@@ -281,15 +307,11 @@ class TestPR1228TorOnion(FiberTest):
             cfg_c.update(cfg_extra)
             fiber_onion_client = self.start_new_fiber(account_client, config=cfg_c)
             time.sleep(2)
-            fiber_onion_client.get_client().connect_peer({"address": onion_addr})
-
-            self._wait_peer(
-                fiber_hs.get_client(), fiber_onion_client.get_pubkey(), timeout=180.0
-            )
-            self._wait_peer(
-                fiber_onion_client.get_client(),
-                fiber_hs.get_pubkey(),
-                timeout=180.0,
+            self._connect_peer_until_visible(
+                fiber_onion_client,
+                fiber_hs,
+                onion_addr,
+                timeout=300.0,
             )
 
             with open(

--- a/test_cases/fiber/devnet/update_channel/test_update_channel.py
+++ b/test_cases/fiber/devnet/update_channel/test_update_channel.py
@@ -165,38 +165,29 @@ class TestUpdateChannel(FiberTest):
         router_length = 2
         for i in range(router_length):
             account_private = self.generate_account(1000)
-            fiber = self.start_new_fiber(account_private)
-            fiber.connect_peer(self.fiber1)
-            fiber.connect_peer(self.fiber2)
+            self.start_new_fiber(account_private)
         for i in range(len(self.fibers) - 1):
             linked_fiber = self.fibers[(i + 1) % len(self.fibers)]
             current_fiber = self.fibers[i]
-            linked_fiber.connect_peer(current_fiber)
-            time.sleep(1)
-            # open channel
-            current_fiber.get_client().open_channel(
-                {
-                    "pubkey": linked_fiber.get_pubkey(),
-                    "funding_amount": hex(500 * 100000000),
-                    "public": True,
-                }
-            )
-            # // AWAITING_TX_SIGNATURES
-            self.wait_for_channel_state(
-                current_fiber.get_client(), linked_fiber.get_pubkey(), "ChannelReady"
+            channel_id = self.open_channel(
+                current_fiber,
+                linked_fiber,
+                500 * 100000000,
+                0,
             )
             for i in range(100):
                 linked_fiber.get_client().update_channel(
                     {
-                        "channel_id": current_fiber.get_client().list_channels({})[
-                            "channels"
-                        ][0]["channel_id"],
+                        "channel_id": channel_id,
                         "tlc_fee_proportional_millionths": hex(2000 + i),
                     }
                 )
                 time.sleep(0.02)
             self.wait_for_channel_state(
-                current_fiber.get_client(), linked_fiber.get_pubkey(), "ChannelReady"
+                current_fiber.get_client(),
+                linked_fiber.get_pubkey(),
+                "ChannelReady",
+                channel_id=channel_id,
             )
         time.sleep(1)
         pub_key = self.fibers[-1].get_client().node_info()["pubkey"]

--- a/test_cases/fiber/devnet/wasm/test_wasm_rpc.py
+++ b/test_cases/fiber/devnet/wasm/test_wasm_rpc.py
@@ -12,6 +12,13 @@ class WasmRpcTest(FiberTest):
     Test cases for the Wasm RPC interface.
     """
 
+    def _channel_by_id(self, client, channel_id):
+        channels = client.list_channels({})["channels"]
+        for channel in channels:
+            if channel["channel_id"] == channel_id:
+                return channel
+        raise AssertionError(f"channel {channel_id} not found in {channels}")
+
     def test_wasm_rpc(self):
         """
         Test the Wasm RPC interface.
@@ -50,12 +57,16 @@ class WasmRpcTest(FiberTest):
             f"not found in actual string '{exc_info.value.args[0]}'"
         )
         time.sleep(1)
-        self.wait_for_channel_state(
+        first_channel_id = self.wait_for_channel_state(
             wasmFiber.get_client(), self.fiber1.get_pubkey(), "ChannelReady"
         )
 
         # accept_channel
         wasm_node_pubkey = wasmFiber.get_client().node_info()["pubkey"]
+        existing_channel_ids = {
+            channel["channel_id"]
+            for channel in wasmFiber.get_client().list_channels({})["channels"]
+        }
         temporary_channel = self.fiber1.get_client().open_channel(
             {
                 "pubkey": wasm_node_pubkey,
@@ -71,22 +82,28 @@ class WasmRpcTest(FiberTest):
             }
         )
         self.wait_for_channel_state(
-            wasmFiber.get_client(), self.fiber1.get_pubkey(), "ChannelReady"
+            wasmFiber.get_client(),
+            self.fiber1.get_pubkey(),
+            "ChannelReady",
+            channel_id=first_channel_id,
+        )
+        accepted_channel_id = self.wait_for_new_channel_state(
+            wasmFiber.get_client(),
+            self.fiber1.get_pubkey(),
+            "ChannelReady",
+            existing_channel_ids,
         )
         # list_channels
-        wasm_list_channel = wasmFiber.get_client().list_channels({})
-        fiber1_list_channel = self.fiber1.get_client().list_channels({})
-        print("wasm_list_channel:", wasm_list_channel)
-        print("fiber1_list_channel:", fiber1_list_channel)
-        assert (
-            wasm_list_channel["channels"][0]["channel_id"]
-            == fiber1_list_channel["channels"][0]["channel_id"]
+        wasm_channel = self._channel_by_id(wasmFiber.get_client(), accepted_channel_id)
+        fiber1_channel = self._channel_by_id(
+            self.fiber1.get_client(), accepted_channel_id
         )
+        print("wasm_channel:", wasm_channel)
+        print("fiber1_channel:", fiber1_channel)
+        assert wasm_channel["channel_id"] == fiber1_channel["channel_id"]
 
         # update_channel
-        update_channel_id = wasmFiber.get_client().list_channels({})["channels"][0][
-            "channel_id"
-        ]
+        update_channel_id = accepted_channel_id
         wasmFiber.get_client().update_channel(
             {
                 "channel_id": update_channel_id,
@@ -94,13 +111,11 @@ class WasmRpcTest(FiberTest):
             }
         )
         time.sleep(1)
-        channels = wasmFiber.get_client().list_channels({})
-        assert channels["channels"][0]["tlc_fee_proportional_millionths"] == hex(2000)
+        channel = self._channel_by_id(wasmFiber.get_client(), update_channel_id)
+        assert channel["tlc_fee_proportional_millionths"] == hex(2000)
 
         # shutdown_channel
-        shutdown_channel_id = wasmFiber.get_client().list_channels({})["channels"][0][
-            "channel_id"
-        ]
+        shutdown_channel_id = accepted_channel_id
         wasmFiber.get_client().shutdown_channel(
             {
                 "channel_id": shutdown_channel_id,

--- a/test_cases/fiber/devnet/watch_tower_wit_tlc/test_shutdown_mid_node.py
+++ b/test_cases/fiber/devnet/watch_tower_wit_tlc/test_shutdown_mid_node.py
@@ -61,13 +61,26 @@ class TestShutdownMidNode(FiberTest):
                 }
             )
             fiber2_invoices.append(fiber2_invoice)
+        payment_hashes = []
         for i in range(N):
-            self.new_fibers[i % len(self.new_fibers)].get_client().send_payment(
-                {
-                    "invoice": fiber2_invoices[i]["invoice_address"],
-                }
+            payment = (
+                self.new_fibers[i % len(self.new_fibers)]
+                .get_client()
+                .send_payment(
+                    {
+                        "invoice": fiber2_invoices[i]["invoice_address"],
+                    }
+                )
             )
+            payment_hashes.append(payment["payment_hash"])
             time.sleep(1)
+        for i, payment_hash in enumerate(payment_hashes):
+            self.wait_payment_state(
+                self.new_fibers[i % len(self.new_fibers)],
+                payment_hash,
+                "Inflight",
+                timeout=60,
+            )
 
         self.fiber2.get_client().shutdown_channel(
             {
@@ -89,21 +102,30 @@ class TestShutdownMidNode(FiberTest):
                 self.Miner.miner_with_version(self.node, "0x0")
             time.sleep(20)
 
-        for channels in self.fiber1.get_client().list_channels({})["channels"]:
-            try:
-                self.fiber1.get_client().shutdown_channel(
+        for fiber in self.new_fibers:
+            channels = fiber.get_client().list_channels(
+                {"pubkey": self.fiber1.get_pubkey()}
+            )["channels"]
+            for channel in channels:
+                if channel["state"]["state_name"] == "Closed":
+                    continue
+                fiber.get_client().shutdown_channel(
                     {
-                        "channel_id": channels["channel_id"],
-                        "close_script": self.get_account_script(
-                            self.Config.ACCOUNT_PRIVATE_1
-                        ),
+                        "channel_id": channel["channel_id"],
+                        "close_script": self.get_account_script(fiber.account_private),
                         "fee_rate": "0x3FC",
                     }
                 )
                 tx_hash = self.wait_and_check_tx_pool_fee(1000, False)
                 self.Miner.miner_until_tx_committed(self.node, tx_hash)
-            except Exception as e:
-                pass
+                self.wait_for_channel_state(
+                    fiber.get_client(),
+                    self.fiber1.get_pubkey(),
+                    "Closed",
+                    120,
+                    True,
+                    channel["channel_id"],
+                )
         after_balance = self.get_fibers_balance()
         result = self.get_balance_change(before_balance, after_balance)
         assert result[0]["udt"] == -800000


### PR DESCRIPTION
## Summary

This PR isolates the rc7 integration regression fixes from the lock-scripts integration PR. It keeps the workflow default on `v0.9.0-rc7` and stabilizes existing suites that failed in the full regression run.

Changes include:

- wait for newly-created channels instead of reusing the first ready channel when multiple channels exist between the same peers
- retry `open_channel` while the peer Init/features are still propagating
- make `connect_peer` wait until the peer appears in `list_peers`
- fix project root detection for suffixed worktree paths
- stabilize the update_channel topology, wasm channel-id selection, Tor onion peer visibility wait, and migration post-upgrade payment retry

## Local validation

Passed locally on macOS with `download/fiber/current/fnn` = `v0.9.0-rc7`:

- `pytest -vv test_cases/fiber/devnet/update_channel/test_update_channel.py::TestUpdateChannel::test_m`
- `pytest -vv test_cases/fiber/devnet/send_payment/mpp/test_mutil_path.py::MutilPathTestCase::test_mutil_to_one_3`
- `pytest -vv test_cases/fiber/devnet/migration/test_large_u128_channel_constraints.py::TestLargeU128ChannelConstraints::test_auto_migrate_v081_explicit_max_tlc_value_in_flight`
- `pytest --collect-only -q` for the wasm and Tor target tests
- `black --check` and `py_compile` for touched Python files

Local limitations:

- Tor target test skips locally because `tor` is not installed on this machine. CI installs Tor and should validate it.
- wasm env preparation hits local mac toolchain/PATH issues (`wasm32-unknown-unknown` clang target / `npx`), so the real validation is expected from the Ubuntu GitHub Actions job.

Related investigation run: https://github.com/nervosnetwork/fiber-py-integration-test/actions/runs/29919881157