### PR TITLE
test: cover Fiber PR #1510 and #1528 regressions

### DIFF
--- a/test_cases/fiber/devnet/send_payment/module/test_pr1510_same_hash_preimage_retention.py
+++ b/test_cases/fiber/devnet/send_payment/module/test_pr1510_same_hash_preimage_retention.py
@@ -1,0 +1,290 @@
+"""PR-1510: retain a preimage while an independent same-hash TLC is pending."""
+
+import http.server
+import json
+import threading
+import time
+
+from framework.basic_fiber import FiberTest
+from framework.util import ckb_hash
+
+
+class WatchtowerRpcRecorder:
+    """Accept Watchtower JSON-RPC calls and record their method and parameters."""
+
+    def __init__(self):
+        self._calls = []
+        self._condition = threading.Condition()
+        self._server = None
+        self._thread = None
+        self.url = None
+
+    def start(self):
+        recorder = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):
+                content_length = int(self.headers.get("Content-Length", 0))
+                payload = json.loads(self.rfile.read(content_length))
+                requests = payload if isinstance(payload, list) else [payload]
+
+                with recorder._condition:
+                    recorder._calls.extend(requests)
+                    recorder._condition.notify_all()
+
+                responses = [
+                    {"jsonrpc": "2.0", "id": request.get("id"), "result": None}
+                    for request in requests
+                ]
+                response = responses if isinstance(payload, list) else responses[0]
+                body = json.dumps(response).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *args):
+                pass
+
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+        self._server = None
+        self._thread = None
+
+    def count(self, method, payment_hash):
+        def contains_hash(value):
+            if isinstance(value, dict):
+                return any(contains_hash(item) for item in value.values())
+            if isinstance(value, list):
+                return any(contains_hash(item) for item in value)
+            return value == payment_hash
+
+        with self._condition:
+            return sum(
+                call.get("method") == method and contains_hash(call.get("params", []))
+                for call in self._calls
+            )
+
+    def wait_for_count(self, method, payment_hash, count, timeout):
+        deadline = time.time() + timeout
+        with self._condition:
+            while time.time() < deadline:
+                if self.count(method, payment_hash) >= count:
+                    return True
+                self._condition.wait(deadline - time.time())
+        return False
+
+
+class TestSameHashPreimageRetention(FiberTest):
+    def test_retains_preimage_until_all_offchain_tlcs_finish(self):
+        recorder = WatchtowerRpcRecorder()
+        recorder.start()
+
+        try:
+            # Observe fiber2's preimage lifecycle through the same Watchtower
+            # interface used by a real standalone Watchtower.
+            self.fiber2.stop()
+            self.fiber2.prepare(
+                {
+                    "fiber_standalone_watchtower_rpc_url": recorder.url,
+                    "fiber_disable_built_in_watchtower": "true",
+                }
+            )
+            self.fiber2.start()
+
+            payee_one = self.start_new_fiber(self.generate_account(10000))
+            payer_two = self.start_new_fiber(self.generate_account(10000))
+            payee_two = self.start_new_fiber(self.generate_account(10000))
+
+            # Two independent payments cross fiber2. Their senders and payees
+            # are different, but both invoices deliberately use the same hash.
+            channel_payer_one_mid = self.open_channel(
+                self.fiber1, self.fiber2, 1000 * 100000000, 0
+            )
+            channel_mid_payee_one = self.open_channel(
+                self.fiber2, payee_one, 1000 * 100000000, 0
+            )
+            channel_payer_two_mid = self.open_channel(
+                payer_two, self.fiber2, 1000 * 100000000, 0
+            )
+            channel_mid_payee_two = self.open_channel(
+                self.fiber2, payee_two, 1000 * 100000000, 0
+            )
+            self.wait_graph_channels_sync(self.fiber1, 4, timeout=120)
+            self.wait_graph_channels_sync(payer_two, 4, timeout=120)
+
+            preimage = self.generate_random_preimage()
+            payment_hash = ckb_hash(preimage)
+            invoice_one = payee_one.get_client().new_invoice(
+                {
+                    "amount": hex(10 * 100000000),
+                    "currency": "Fibd",
+                    "description": "PR-1510 same-hash payment one",
+                    "payment_hash": payment_hash,
+                    "hash_algorithm": "ckb_hash",
+                    "expiry": "0xe10",
+                    "final_cltv": "0x28",
+                }
+            )
+            invoice_two = payee_two.get_client().new_invoice(
+                {
+                    "amount": hex(10 * 100000000),
+                    "currency": "Fibd",
+                    "description": "PR-1510 same-hash payment two",
+                    "payment_hash": payment_hash,
+                    "hash_algorithm": "ckb_hash",
+                    "expiry": "0xe10",
+                    "final_cltv": "0x28",
+                }
+            )
+            payment_one = self.fiber1.get_client().send_payment(
+                {"invoice": invoice_one["invoice_address"]}
+            )
+            payment_two = payer_two.get_client().send_payment(
+                {"invoice": invoice_two["invoice_address"]}
+            )
+            assert payment_one["payment_hash"] == payment_hash
+            assert payment_two["payment_hash"] == payment_hash
+            self.wait_invoice_state(payee_one, payment_hash, "Received", timeout=120)
+            self.wait_invoice_state(payee_two, payment_hash, "Received", timeout=120)
+
+            all_channel_ids = (
+                channel_payer_one_mid,
+                channel_mid_payee_one,
+                channel_payer_two_mid,
+                channel_mid_payee_two,
+            )
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                channels = {
+                    channel["channel_id"]: channel
+                    for channel in self.fiber2.get_client().list_channels({})[
+                        "channels"
+                    ]
+                }
+                channels_ready = all(
+                    channels[channel_id]["state"]["state_name"] == "ChannelReady"
+                    for channel_id in all_channel_ids
+                )
+                pending_by_channel = {
+                    channel_id: [
+                        tlc
+                        for tlc in channels[channel_id].get("pending_tlcs", [])
+                        if tlc["payment_hash"] == payment_hash
+                    ]
+                    for channel_id in all_channel_ids
+                }
+                all_tlcs_committed = all(
+                    len(pending_by_channel[channel_id]) == 1
+                    and "Committed"
+                    in pending_by_channel[channel_id][0]["status"].values()
+                    for channel_id in all_channel_ids
+                )
+                if all_tlcs_committed and channels_ready:
+                    break
+                time.sleep(0.5)
+            else:
+                assert False, "same-hash TLCs were not pending on all four channels"
+
+            payee_one.get_client().settle_invoice(
+                {"payment_hash": payment_hash, "payment_preimage": preimage}
+            )
+
+            first_payment_channels = (
+                channel_payer_one_mid,
+                channel_mid_payee_one,
+            )
+            second_payment_channels = (
+                channel_payer_two_mid,
+                channel_mid_payee_two,
+            )
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                channels = {
+                    channel["channel_id"]: channel
+                    for channel in self.fiber2.get_client().list_channels({})[
+                        "channels"
+                    ]
+                }
+                pending_by_channel = {
+                    channel_id: [
+                        tlc
+                        for tlc in channels[channel_id].get("pending_tlcs", [])
+                        if tlc["payment_hash"] == payment_hash
+                    ]
+                    for channel_id in all_channel_ids
+                }
+                first_payment_cleared = all(
+                    not pending_by_channel[channel_id]
+                    for channel_id in first_payment_channels
+                )
+                second_payment_still_pending = all(
+                    len(pending_by_channel[channel_id]) == 1
+                    and "Committed"
+                    in pending_by_channel[channel_id][0]["status"].values()
+                    for channel_id in second_payment_channels
+                )
+                channels_ready = all(
+                    channels[channel_id]["state"]["state_name"] == "ChannelReady"
+                    for channel_id in all_channel_ids
+                )
+                if (
+                    first_payment_cleared
+                    and second_payment_still_pending
+                    and channels_ready
+                ):
+                    break
+                time.sleep(0.5)
+            else:
+                assert False, (
+                    "first payment did not settle while the independent "
+                    "same-hash payment stayed pending"
+                )
+
+            assert recorder.wait_for_count(
+                "create_preimage", payment_hash, 1, timeout=5
+            ), "fiber2 did not publish the fulfilled TLC preimage"
+            assert not recorder.wait_for_count(
+                "remove_preimage", payment_hash, 1, timeout=2
+            ), (
+                "fiber2 removed the preimage while another off-chain channel "
+                "still had a pending TLC with the same payment hash"
+            )
+
+            payee_two.get_client().settle_invoice(
+                {"payment_hash": payment_hash, "payment_preimage": preimage}
+            )
+
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                channels = self.fiber2.get_client().list_channels({})["channels"]
+                if all(
+                    payment_hash
+                    not in [
+                        tlc["payment_hash"] for tlc in channel.get("pending_tlcs", [])
+                    ]
+                    for channel in channels
+                ):
+                    break
+                time.sleep(0.5)
+            else:
+                assert False, "second same-hash TLC did not settle"
+
+            assert recorder.wait_for_count(
+                "remove_preimage", payment_hash, 1, timeout=5
+            ), "fiber2 did not remove the preimage after the last TLC finished"
+            assert recorder.count("remove_preimage", payment_hash) == 1
+            self.wait_payment_state(self.fiber1, payment_hash, "Success", timeout=60)
+            self.wait_payment_state(payer_two, payment_hash, "Success", timeout=60)
+        finally:
+            recorder.stop()

--- a/test_cases/fiber/devnet/watch_tower/test_pr1528_abort_scan_on_rpc_error.py
+++ b/test_cases/fiber/devnet/watch_tower/test_pr1528_abort_scan_on_rpc_error.py
@@ -1,0 +1,165 @@
+"""PR-1528: abort a watchtower settlement scan when pagination RPCs fail."""
+
+import time
+from pathlib import Path
+
+from framework.basic_fiber import FiberTest
+from framework.ckb_rpc_proxy import CkbRpcProxy
+
+
+class TestWatchtowerPaginationRpcError(FiberTest):
+    start_fiber_config = {"fiber_watchtower_check_interval_seconds": 5}
+
+    def test_pagination_rpc_errors_abort_current_scan(self):
+        proxy = CkbRpcProxy(self.node.rpcUrl)
+        proxy.start()
+
+        try:
+            # Use a standalone watchtower so unrelated Fiber tasks cannot consume
+            # the proxy notification used to place the error injection.
+            self.fiber3 = self.start_new_fiber(
+                self.generate_random_preimage(),
+                {"ckb_rpc_url": proxy.url},
+            )
+
+            self.fiber2.stop()
+            self.fiber2.prepare(
+                {
+                    "fiber_standalone_watchtower_rpc_url": self.fiber3.get_client().url,
+                    "fiber_disable_built_in_watchtower": "true",
+                }
+            )
+            self.fiber2.start()
+
+            # Open the channel while fiber3 is online so it persists the watch data.
+            channel_id = self.open_channel(
+                self.fiber1,
+                self.fiber2,
+                1000 * 100000000,
+                1,
+            )
+
+            # Keep fiber3's persisted watch entry while the commitment transaction
+            # is submitted and committed.
+            self.fiber3.stop()
+            self.fiber1.get_client().shutdown_channel(
+                {"channel_id": channel_id, "force": True}
+            )
+            commitment_tx = self.wait_and_check_tx_pool_fee(1000, False)
+            self.Miner.miner_until_tx_committed(self.node, commitment_tx)
+            for _ in range(2):
+                self.Miner.miner_with_version(self.node, "0x0")
+
+            log_path = Path(self.fiber3.tmp_path) / "node.log"
+            log_offset = log_path.stat().st_size
+
+            # The first get_transactions call is the outer lookup for the
+            # commitment transaction. It must succeed before the two pagination
+            # loops covered by PR-1528 are reached.
+            proxy.notify_on_method("get_transactions")
+            self.fiber3.start()
+            assert proxy.wait_for_method(
+                20
+            ), "watchtower did not look up the committed force-close transaction"
+
+            proxy.block_method_with_error(
+                "get_transactions",
+                code=-32000,
+                message="PR-1528 injected pagination error",
+            )
+            proxy.block_method_with_error(
+                "get_cells",
+                code=-32000,
+                message="PR-1528 injected pagination error",
+            )
+
+            scan_log = ""
+            try:
+                deadline = time.time() + 10
+                while time.time() < deadline:
+                    with log_path.open("rb") as log_file:
+                        log_file.seek(log_offset)
+                        scan_log = log_file.read().decode(errors="replace")
+
+                    if (
+                        "Failed to get transactions:" in scan_log
+                        and "Failed to get cells:" in scan_log
+                        and "PeriodicCheck finished elapsed:" in scan_log
+                    ):
+                        break
+
+                    # A vulnerable build retries the first failed request in a
+                    # tight loop. Stop observing early so an A/B run fails fast.
+                    if (
+                        scan_log.count("Failed to get transactions:") >= 3
+                        or scan_log.count("Failed to get cells:") >= 3
+                    ):
+                        break
+                    time.sleep(0.2)
+            finally:
+                # Also lets a vulnerable build escape its loop before teardown.
+                proxy.unblock_methods()
+                time.sleep(1)
+
+            lines = scan_log.splitlines()
+            scan_start = next(
+                (
+                    index
+                    for index, line in enumerate(lines)
+                    if "PeriodicCheck started" in line
+                ),
+                None,
+            )
+            scan_finish = next(
+                (
+                    index
+                    for index, line in enumerate(lines)
+                    if scan_start is not None
+                    and index > scan_start
+                    and "PeriodicCheck finished elapsed:" in line
+                ),
+                None,
+            )
+            assert scan_start is not None and scan_finish is not None, scan_log
+
+            scan_lines = lines[scan_start : scan_finish + 1]
+            transaction_errors = [
+                index
+                for index, line in enumerate(scan_lines)
+                if "Failed to get transactions:" in line
+                and "PR-1528 injected pagination error" in line
+                and "aborting settlement scan" in line
+            ]
+            cell_errors = [
+                index
+                for index, line in enumerate(scan_lines)
+                if "Failed to get cells:" in line
+                and "PR-1528 injected pagination error" in line
+                and "aborting settlement scan" in line
+            ]
+
+            assert len(transaction_errors) == 1, scan_lines
+            assert len(cell_errors) == 1, scan_lines
+            assert transaction_errors[0] < cell_errors[0], scan_lines
+
+            # The failed scan ended, so the next periodic scan can run normally.
+            recovery_offset = log_path.stat().st_size
+            recovery_log = ""
+            deadline = time.time() + 15
+            while time.time() < deadline:
+                with log_path.open("rb") as log_file:
+                    log_file.seek(recovery_offset)
+                    recovery_log = log_file.read().decode(errors="replace")
+                if (
+                    "PeriodicCheck started" in recovery_log
+                    and "PeriodicCheck finished elapsed:" in recovery_log
+                ):
+                    break
+                time.sleep(0.5)
+
+            assert "PeriodicCheck started" in recovery_log, recovery_log
+            assert "PeriodicCheck finished elapsed:" in recovery_log, recovery_log
+            assert self.fiber3.get_client().node_info()["pubkey"]
+        finally:
+            proxy.unblock_methods()
+            proxy.stop()


### PR DESCRIPTION
## Summary

- add an integration regression test for [nervosnetwork/fiber#1510](https://github.com/nervosnetwork/fiber/pull/1510), covering concurrent off-chain TLCs that share one payment hash
- add an integration regression test for [nervosnetwork/fiber#1528](https://github.com/nervosnetwork/fiber/pull/1528), covering Watchtower pagination RPC errors and scan recovery
- place the PR #1510 test in the existing send-payment module shard; PR #1528 is collected by the existing Watchtower shard, with no workflow changes

## Coverage

### PR #1510

Two independent hold-invoice payments use the same payment hash and pass through the same intermediate node. The test settles them separately and verifies that the intermediate node:

- keeps the preimage while the second off-chain TLC is still committed
- removes the preimage only after all same-hash TLCs finish
- completes both payments successfully

### PR #1528

A standalone Watchtower scans a committed force-close transaction through the existing CKB RPC proxy. The test injects errors into both pagination RPC loops and verifies that:

- each failing loop aborts the current scan instead of retrying indefinitely
- the transaction scan aborts before the cell scan
- a later periodic scan recovers after the RPC errors are removed

## Validation

- current Fiber develop binary `5db52a2`: `2 passed in 137.66s`
- PR #1510 pre-fix binary `e783a95`: fails on premature `remove_preimage`
- PR #1528 pre-fix binary `2d89d76`: fails because the pagination loop continues after the RPC error
- Black: passed
- `py_compile`: passed
- existing CI shard collection: both new tests collected
