### PR TITLE
ci: improve fiber sync Discord report readability

### DIFF
--- a/.github/workflows/fiber-sync-state.yml
+++ b/.github/workflows/fiber-sync-state.yml
@@ -1,5 +1,5 @@
 # Daily mainnet + testnet graph sync measurement.
-# Mirrors fiber-testnet.yml setup; posts RESULT lines to Discord after the run.
+# Mirrors fiber-testnet.yml setup; posts a readable sync summary to Discord.
 
 name: fiber sync state
 
@@ -38,6 +38,7 @@ jobs:
     timeout-minutes: 180
     outputs:
       sync_results: ${{ steps.capture.outputs.sync_results }}
+      discord_body: ${{ steps.capture.outputs.discord_body }}
 
     steps:
       - uses: actions/checkout@v3
@@ -82,6 +83,11 @@ jobs:
       - name: Capture RESULT lines for Discord
         id: capture
         if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          FIBER_BRANCH: ${{ github.event.inputs.GitBranch || 'develop' }}
+          ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -e
           RESULTS=""
@@ -91,19 +97,109 @@ jobs:
             RESULTS=$(grep -E '\[(main|test)_net\] RESULT' sync_state.log || true)
           fi
           if [ -z "$RESULTS" ]; then
-            RESULTS="No RESULT lines captured (job=${{ job.status }})"
+            RESULTS="No RESULT lines captured (job=${JOB_STATUS})"
           fi
           echo "Captured results:"
           echo "$RESULTS"
+
           {
             echo "sync_results<<EOF"
             printf '%s\n' "$RESULTS"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
-          echo "# Fiber Sync State Results" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          printf '%s\n' "$RESULTS" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          # Human-readable Discord body (mainnet / testnet cards)
+          DISCORD_BODY=$(RESULTS="$RESULTS" JOB_STATUS="$JOB_STATUS" \
+            FIBER_BRANCH="$FIBER_BRANCH" ACTOR="$ACTOR" RUN_URL="$RUN_URL" \
+            python3 <<'PY'
+          import os
+          import re
+
+          results = os.environ.get("RESULTS", "").strip()
+          job_status = os.environ.get("JOB_STATUS", "unknown")
+          fiber_branch = os.environ.get("FIBER_BRANCH", "develop")
+          actor = os.environ.get("ACTOR", "")
+          run_url = os.environ.get("RUN_URL", "")
+
+          reason_map = {
+              "graph_stable": ("已稳定", "counts unchanged for 1 min"),
+              "max_duration_reached": ("超时截断", "hit max duration"),
+          }
+          net_map = {
+              "main_net": ("🟢 Mainnet", "主网"),
+              "test_net": ("🔵 Testnet", "测试网"),
+          }
+
+          def fmt_duration(seconds: float) -> str:
+              total = int(round(float(seconds)))
+              m, s = divmod(total, 60)
+              h, m = divmod(m, 60)
+              if h:
+                  return f"{h}h {m}m {s}s"
+              if m:
+                  return f"{m}m {s}s"
+              return f"{s}s"
+
+          pattern = re.compile(
+              r"\[(?P<net>main_net|test_net)\] RESULT "
+              r"elapsed=(?P<elapsed>[\d.]+)s "
+              r"graph_channels=(?P<channels>\d+) "
+              r"graph_nodes=(?P<nodes>\d+) "
+              r"list_peers=(?P<peers>\d+) "
+              r"reason=(?P<reason>\w+)"
+          )
+
+          blocks = []
+          for line in results.splitlines():
+              m = pattern.search(line.strip())
+              if not m:
+                  continue
+              title, subtitle = net_map.get(m.group("net"), (m.group("net"), ""))
+              reason = m.group("reason")
+              reason_zh, reason_en = reason_map.get(reason, (reason, reason))
+              elapsed = fmt_duration(m.group("elapsed"))
+              blocks.append(
+                  "\n".join(
+                      [
+                          f"**{title}** · {subtitle}",
+                          f"⏱ 耗时 **{elapsed}**  (`{m.group('elapsed')}s`)",
+                          f"📡 graph_channels **{m.group('channels')}**",
+                          f"🧭 graph_nodes **{m.group('nodes')}**",
+                          f"🔗 list_peers **{m.group('peers')}**",
+                          f"✅ 状态 **{reason_zh}**  ({reason_en})",
+                      ]
+                  )
+              )
+
+          header = (
+              f"Fiber branch `{fiber_branch}` · by `{actor}` · job `{job_status}`"
+          )
+          if blocks:
+              body = header + "\n\n" + "\n\n".join(blocks)
+          else:
+              body = header + "\n\n" + f"```\n{results}\n```"
+
+          body += f"\n\n[查看完整运行日志]({run_url})"
+          print(body)
+          PY
+          )
+
+          {
+            echo "discord_body<<EOF"
+            printf '%s\n' "$DISCORD_BODY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "# Fiber Sync State Results"
+            echo
+            echo "$DISCORD_BODY"
+            echo
+            echo '## Raw RESULT'
+            echo '```'
+            printf '%s\n' "$RESULTS"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish reports
         if: always()
@@ -126,17 +222,14 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SYNC }}
-          title: "Fiber Sync State Succeeded"
-          description: |
-            Daily mainnet/testnet graph sync finished for fiber branch `${{ github.event.inputs.GitBranch || 'develop' }}`.
-            Triggered by `${{ github.actor }}`.
-
-            ```
-            ${{ needs.build.outputs.sync_results }}
-            ```
-
-            Check run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          color: 0x00ff00
+          username: Fiber Sync
+          noprefix: true
+          nocontext: true
+          nodetail: true
+          title: "Fiber Graph Sync · 主网 / 测试网"
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          description: ${{ needs.build.outputs.discord_body }}
+          color: 0x2ecc71
 
       - name: Notify Discord on failure
         if: needs.build.result != 'success'
@@ -144,14 +237,12 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_SYNC }}
+          username: Fiber Sync
           content: "<@802020984097734656>"
-          title: "Fiber Sync State Failed"
-          description: |
-            Fiber sync state finished with **${{ needs.build.result }}** for fiber branch `${{ github.event.inputs.GitBranch || 'develop' }}`.
-
-            ```
-            ${{ needs.build.outputs.sync_results }}
-            ```
-
-            Check run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          color: 0xff0000
+          noprefix: true
+          nocontext: true
+          nodetail: true
+          title: "Fiber Graph Sync · 失败 (${{ needs.build.result }})"
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          description: ${{ needs.build.outputs.discord_body }}
+          color: 0xe74c3c


### PR DESCRIPTION
## Summary
- Format Discord sync-state notifications into clear mainnet/testnet cards (duration, channels, nodes, peers, status).
- Convert elapsed seconds to human time (e.g. `95.50s` → `1m 36s`).
- Hide noisy embed context (`Repository` / `Ref` / `Event` / `Success:` prefix) via `nocontext` + `nodetail` + `noprefix`.

### Before
```
Success: Fiber Sync State Succeeded
...
[main_net] RESULT elapsed=95.50s graph_channels=17 ...
[test_net] RESULT elapsed=226.64s graph_channels=927 ...
Repository / Ref / Event / ...
```

### After (preview)
```
Fiber Graph Sync · 主网 / 测试网

Fiber branch develop · by gpBlockchain · job success

🟢 Mainnet · 主网
⏱ 耗时 1m 36s
📡 graph_channels 17
🧭 graph_nodes 7
🔗 list_peers 1
✅ 状态 已稳定

🔵 Testnet · 测试网
⏱ 耗时 3m 47s
📡 graph_channels 927
🧭 graph_nodes 65
🔗 list_peers 1
✅ 状态 已稳定
```

## Test plan
- [ ] Merge and run `fiber sync state` via workflow_dispatch
- [ ] Confirm Discord message is card-style without Repository/Ref noise