### PR TITLE
test: cover multi-channel restart and batch payment recovery

### DIFF
--- a/test_cases/fiber/devnet/connect_peer/test_channel_actor_disconnect_reconnect.py
+++ b/test_cases/fiber/devnet/connect_peer/test_channel_actor_disconnect_reconnect.py
@@ -4,6 +4,9 @@ PR #1217 keeps channel actors alive across peer disconnects and lets the
 channel actor drive reestablish on reconnect. The observable contract from
 Python is simple: a ready channel must stay usable after disconnect/reconnect,
 including when there is a pending hold TLC during the offline window.
+
+The multi-channel case verifies that every channel actor becomes usable again
+after both endpoints restart, including a channel with a pending TLC.
 """
 
 import hashlib
@@ -24,6 +27,126 @@ def _pending_tlc_count(fiber, peer_pubkey):
 
 
 class TestChannelActorDisconnectReconnect(FiberTest):
+    def _build_direct_router(self, sender, receiver, channel_outpoint, amount):
+        last_error = None
+        for _ in range(60):
+            try:
+                router = sender.get_client().build_router(
+                    {
+                        "amount": hex(amount),
+                        "udt_type_script": None,
+                        "hops_info": [
+                            {
+                                "pubkey": receiver.get_pubkey(),
+                                "channel_outpoint": channel_outpoint,
+                            }
+                        ],
+                        "final_tlc_expiry_delta": None,
+                    }
+                )["router_hops"]
+                assert len(router) == 1
+                assert router[0]["channel_outpoint"] == channel_outpoint
+                return router
+            except Exception as error:
+                last_error = error
+                time.sleep(0.5)
+        assert False, f"could not build router for {channel_outpoint}: {last_error}"
+
+    def _send_keysend_via_channel(self, sender, receiver, channel_outpoint, amount):
+        payment = sender.get_client().send_payment_with_router(
+            {
+                "payment_hash": None,
+                "invoice": None,
+                "keysend": True,
+                "custom_records": None,
+                "dry_run": False,
+                "udt_type_script": None,
+                "router": self._build_direct_router(
+                    sender, receiver, channel_outpoint, amount
+                ),
+            }
+        )
+        self.wait_payment_state(sender, payment["payment_hash"], "Success", 120)
+
+    def _wait_for_both_peers(self, fiber1_pubkey, fiber2_pubkey, timeout=60):
+        consecutive = 0
+        for _ in range(timeout * 2):
+            fiber1_peers = self.fiber1.get_client().list_peers().get("peers") or []
+            fiber2_peers = self.fiber2.get_client().list_peers().get("peers") or []
+            fiber1_connected = any(
+                peer.get("pubkey") == fiber2_pubkey for peer in fiber1_peers
+            )
+            fiber2_connected = any(
+                peer.get("pubkey") == fiber1_pubkey for peer in fiber2_peers
+            )
+            if fiber1_connected and fiber2_connected:
+                consecutive += 1
+                if consecutive == 3:
+                    return
+            else:
+                consecutive = 0
+            time.sleep(0.5)
+        assert False, "peers did not remain connected on both nodes"
+
+    def _wait_for_channels_without_pending_tlcs(
+        self, channel_ids, fiber1_pubkey, fiber2_pubkey, timeout=60
+    ):
+        last_snapshot = {}
+        for _ in range(timeout * 2):
+            fiber1_channels = self.fiber1.get_client().list_channels(
+                {"pubkey": fiber2_pubkey}
+            )["channels"]
+            fiber2_channels = self.fiber2.get_client().list_channels(
+                {"pubkey": fiber1_pubkey}
+            )["channels"]
+            fiber1_by_id = {
+                channel["channel_id"]: channel for channel in fiber1_channels
+            }
+            fiber2_by_id = {
+                channel["channel_id"]: channel for channel in fiber2_channels
+            }
+            last_snapshot = {}
+            for channel_id in channel_ids:
+                fiber1_channel = fiber1_by_id.get(channel_id)
+                fiber2_channel = fiber2_by_id.get(channel_id)
+                last_snapshot[channel_id] = {
+                    "fiber1": (
+                        None
+                        if fiber1_channel is None
+                        else {
+                            "state": fiber1_channel.get("state", {}).get("state_name"),
+                            "pending_payment_hashes": [
+                                tlc.get("payment_hash")
+                                for tlc in fiber1_channel.get("pending_tlcs", [])
+                            ],
+                        }
+                    ),
+                    "fiber2": (
+                        None
+                        if fiber2_channel is None
+                        else {
+                            "state": fiber2_channel.get("state", {}).get("state_name"),
+                            "pending_payment_hashes": [
+                                tlc.get("payment_hash")
+                                for tlc in fiber2_channel.get("pending_tlcs", [])
+                            ],
+                        }
+                    ),
+                }
+            if all(
+                channel_id in fiber1_by_id
+                and channel_id in fiber2_by_id
+                and fiber1_by_id[channel_id].get("pending_tlcs", []) == []
+                and fiber2_by_id[channel_id].get("pending_tlcs", []) == []
+                for channel_id in channel_ids
+            ):
+                return
+            time.sleep(0.5)
+        assert False, (
+            "pending TLCs did not clear on every restarted channel; "
+            f"last_snapshot={last_snapshot}"
+        )
+
     def _disconnect_and_reconnect(self):
         self.fiber1.get_client().disconnect_peer({"pubkey": self.fiber2.get_pubkey()})
         time.sleep(2)
@@ -79,3 +202,144 @@ class TestChannelActorDisconnectReconnect(FiberTest):
         self.wait_invoice_state(self.fiber2, payment_hash, "Paid", 120, 1)
         assert _pending_tlc_count(self.fiber1, self.fiber2.get_pubkey()) == 0
         assert _pending_tlc_count(self.fiber2, self.fiber1.get_pubkey()) == 0
+
+    def test_multiple_channels_with_pending_tlc_survive_both_nodes_restart(self):
+        fiber1_pubkey = self.fiber1.get_pubkey()
+        fiber2_pubkey = self.fiber2.get_pubkey()
+        channel_ids = []
+        for _ in range(3):
+            channel_ids.append(
+                self.open_channel(
+                    self.fiber1,
+                    self.fiber2,
+                    500 * 100000000,
+                    0,
+                )
+            )
+
+        channels = self.fiber1.get_client().list_channels(
+            {"pubkey": self.fiber2.get_pubkey()}
+        )["channels"]
+        channels_by_id = {channel["channel_id"]: channel for channel in channels}
+        assert all(channel_id in channels_by_id for channel_id in channel_ids)
+        channel_outpoints = [
+            channels_by_id[channel_id]["channel_outpoint"] for channel_id in channel_ids
+        ]
+
+        # Exercise every channel and give fiber2 enough balance for the
+        # reverse, per-channel payments performed after restart.
+        for channel_outpoint in channel_outpoints:
+            self._send_keysend_via_channel(
+                self.fiber1,
+                self.fiber2,
+                channel_outpoint,
+                10 * 100000000,
+            )
+        self._wait_for_channels_without_pending_tlcs(
+            channel_ids, fiber1_pubkey, fiber2_pubkey
+        )
+
+        preimage = self.generate_random_preimage()
+        payment_hash = _sha256_hex(preimage)
+        invoice = self.fiber2.get_client().new_invoice(
+            {
+                "amount": hex(1 * 100000000),
+                "currency": "Fibd",
+                "description": "multi-channel hold TLC across restart",
+                "expiry": "0xe10",
+                "final_cltv": "0x28",
+                "payment_hash": payment_hash,
+                "hash_algorithm": "sha256",
+            }
+        )
+        payment = self.fiber1.get_client().send_payment_with_router(
+            {
+                "payment_hash": None,
+                "invoice": invoice["invoice_address"],
+                "keysend": False,
+                "custom_records": None,
+                "dry_run": False,
+                "udt_type_script": None,
+                "router": self._build_direct_router(
+                    self.fiber1,
+                    self.fiber2,
+                    channel_outpoints[0],
+                    1 * 100000000,
+                ),
+            }
+        )
+        self.wait_invoice_state(self.fiber2, payment_hash, "Received", 120, 1)
+        self.wait_payment_state(self.fiber1, payment_hash, "Inflight", 30)
+        channels = self.fiber1.get_client().list_channels({"pubkey": fiber2_pubkey})[
+            "channels"
+        ]
+        hold_channel = next(
+            channel for channel in channels if channel["channel_id"] == channel_ids[0]
+        )
+        assert any(
+            tlc.get("payment_hash") == payment_hash
+            for tlc in hold_channel.get("pending_tlcs", [])
+        )
+
+        self.fiber1.stop()
+        self.fiber2.stop()
+        self.fiber2.start(fnn_log_level=self.fnn_log_level)
+        self.fiber1.start(fnn_log_level=self.fnn_log_level)
+        fiber1_peers = self.fiber1.get_client().list_peers().get("peers") or []
+        if not any(peer.get("pubkey") == fiber2_pubkey for peer in fiber1_peers):
+            self.fiber1.connect_peer(self.fiber2)
+        self._wait_for_both_peers(fiber1_pubkey, fiber2_pubkey)
+
+        assert (
+            self.fiber2.get_client().get_invoice({"payment_hash": payment_hash})[
+                "status"
+            ]
+            == "Received"
+        )
+        self.wait_payment_state(self.fiber1, payment_hash, "Inflight", 30)
+
+        self.fiber2.get_client().settle_invoice(
+            {"payment_hash": payment_hash, "payment_preimage": preimage}
+        )
+        self.wait_payment_state(self.fiber1, payment["payment_hash"], "Success", 120)
+        self.wait_invoice_state(self.fiber2, payment_hash, "Paid", 120, 1)
+
+        # Stored ChannelReady state alone is not enough: force a real payment
+        # through every channel in both directions after reestablishment.
+        for channel_outpoint in channel_outpoints:
+            self._send_keysend_via_channel(
+                self.fiber1,
+                self.fiber2,
+                channel_outpoint,
+                1 * 100000000,
+            )
+            self._send_keysend_via_channel(
+                self.fiber2,
+                self.fiber1,
+                channel_outpoint,
+                1 * 100000000,
+            )
+
+        self._wait_for_channels_without_pending_tlcs(
+            channel_ids, fiber1_pubkey, fiber2_pubkey
+        )
+        self._wait_for_both_peers(fiber1_pubkey, fiber2_pubkey)
+
+        for fiber, peer_pubkey in (
+            (self.fiber1, fiber2_pubkey),
+            (self.fiber2, fiber1_pubkey),
+        ):
+            channels = fiber.get_client().list_channels({"pubkey": peer_pubkey})[
+                "channels"
+            ]
+            restarted_channels = [
+                channel for channel in channels if channel["channel_id"] in channel_ids
+            ]
+            assert len(restarted_channels) == len(channel_ids)
+            assert all(
+                channel["state"]["state_name"] == "ChannelReady"
+                for channel in restarted_channels
+            )
+            assert all(
+                channel.get("pending_tlcs", []) == [] for channel in restarted_channels
+            )

--- a/test_cases/fiber/devnet/settle_invoice/test_batch_settle.py
+++ b/test_cases/fiber/devnet/settle_invoice/test_batch_settle.py
@@ -4,6 +4,39 @@ from framework.basic_fiber import FiberTest
 from test_cases.fiber.devnet.settle_invoice.test_settle_invoice import sha256_hex
 
 
+def _wait_all_payments_success(payment_groups, timeout=120):
+    pending = [
+        (fiber, payment_hash)
+        for fiber, payment_hashes in payment_groups
+        for payment_hash in payment_hashes
+    ]
+    deadline = time.monotonic() + timeout
+    last_states = {}
+    while pending and time.monotonic() < deadline:
+        still_pending = []
+        for fiber, payment_hash in pending:
+            client = fiber.get_client()
+            rpc_url = client.url
+            payment = client.get_payment({"payment_hash": payment_hash})
+            last_states[(rpc_url, payment_hash)] = payment["status"]
+            if payment["status"] == "Failed":
+                assert False, f"payment failed on {rpc_url}: {payment}"
+            if payment["status"] != "Success":
+                still_pending.append((fiber, payment_hash))
+        pending = still_pending
+        if pending:
+            time.sleep(1)
+    remaining = [
+        {
+            "rpc_url": fiber.get_client().url,
+            "payment_hash": payment_hash,
+            "status": last_states.get((fiber.get_client().url, payment_hash)),
+        }
+        for fiber, payment_hash in pending
+    ]
+    assert not pending, f"payments timed out after {timeout}s: {remaining}"
+
+
 class BatchSettle(FiberTest):
 
     def test_batch_settle(self):
@@ -27,6 +60,7 @@ class BatchSettle(FiberTest):
             fiber1_invoices = []
             fiber1_preimages = []
             fiber1_invoice_hashes = []
+            fiber3_sent_payment_hashes = []
             for i in range(fiber1_invoice_size):
                 preimage = self.generate_random_preimage()
                 invoice_hash = sha256_hex(preimage)
@@ -48,6 +82,7 @@ class BatchSettle(FiberTest):
             fiber3_invoices = []
             fiber3_preimages = []
             fiber3_invoice_hashes = []
+            fiber1_sent_payment_hashes = []
             for i in range(fiber3_invoice_size):
                 preimage = self.generate_random_preimage()
                 invoice_hash = sha256_hex(preimage)
@@ -66,19 +101,21 @@ class BatchSettle(FiberTest):
                 fiber3_invoice_hashes.append(invoice_hash)
             # fiber3 -> fiber1
             for invoice in fiber1_invoices:
-                self.fiber3.get_client().send_payment(
+                payment = self.fiber3.get_client().send_payment(
                     {
                         "invoice": invoice["invoice_address"],
                     }
                 )
+                fiber3_sent_payment_hashes.append(payment["payment_hash"])
 
             # fiber1 -> fiber3
             for invoice in fiber3_invoices:
-                self.fiber1.get_client().send_payment(
+                payment = self.fiber1.get_client().send_payment(
                     {
                         "invoice": invoice["invoice_address"],
                     }
                 )
+                fiber1_sent_payment_hashes.append(payment["payment_hash"])
 
             # wait all invoice ture receive
             for invoice in fiber3_invoices:
@@ -117,6 +154,14 @@ class BatchSettle(FiberTest):
                 self.wait_invoice_state(
                     self.fiber3, invoice["invoice"]["data"]["payment_hash"], "Paid"
                 )
+
+            _wait_all_payments_success(
+                (
+                    (self.fiber3, fiber3_sent_payment_hashes),
+                    (self.fiber1, fiber1_sent_payment_hashes),
+                )
+            )
+
             time.sleep(10)
             after_balances = self.get_fibers_balance()
             print(
@@ -196,3 +241,41 @@ class BatchSettle(FiberTest):
             )
             assert before_balances[2]["ckb"]["received_tlc_balance"] == 0
             assert after_balances[2]["ckb"]["received_tlc_balance"] == 0
+
+            fiber1_peers = {
+                peer["pubkey"]
+                for peer in self.fiber1.get_client().list_peers()["peers"]
+            }
+            fiber2_peers = {
+                peer["pubkey"]
+                for peer in self.fiber2.get_client().list_peers()["peers"]
+            }
+            fiber3_peers = {
+                peer["pubkey"]
+                for peer in self.fiber3.get_client().list_peers()["peers"]
+            }
+            assert self.fiber2.get_pubkey() in fiber1_peers
+            assert {
+                self.fiber1.get_pubkey(),
+                self.fiber3.get_pubkey(),
+            } <= fiber2_peers
+            assert self.fiber2.get_pubkey() in fiber3_peers
+
+            final_payment_hash = self.send_payment(
+                self.fiber1, self.fiber3, 1 * 100000000
+            )
+            assert (
+                self.fiber1.get_client().get_payment(
+                    {"payment_hash": final_payment_hash}
+                )["status"]
+                == "Success"
+            )
+            reverse_payment_hash = self.send_payment(
+                self.fiber3, self.fiber1, 1 * 100000000
+            )
+            assert (
+                self.fiber3.get_client().get_payment(
+                    {"payment_hash": reverse_payment_hash}
+                )["status"]
+                == "Success"
+            )


### PR DESCRIPTION
## Summary

- extend the existing channel reestablishment suite with three parallel channels, one pending hold TLC, and a restart of both endpoints
- rebuild routes after restart and complete bidirectional payments through every saved `channel_outpoint`
- strengthen the existing 120-payment batch-settle case by checking every sender-side payment reaches `Success`, expected peers remain connected, and fresh payments still work in both directions

## Context

This adds Python-observable integration coverage around the bounded peer-message processing introduced by `nervosnetwork/fiber#1554` and subsequent channel reestablishment changes.

The `>400` persisted-channel regression from `nervosnetwork/fiber#1586` is covered separately by the stability workflow. This PR intentionally focuses on deterministic business behavior that the RPC integration framework can verify; exact message/byte limits and ban accounting remain Rust policy/network test concerns.

## Validation

Tested with a freshly built Fiber `develop` binary at `eaab8dc6`, which includes `nervosnetwork/fiber#1595`:

- multi-channel restart and per-channel payment: `1 passed in 73.02s`
- 120-payment bidirectional batch settlement: `1 passed in 111.24s`
- existing single-channel reconnect regressions: `2 passed in 63.41s`
- Python compilation, Black formatting, pytest collection, and `git diff --check`

No shared framework or CI workflow changes are required; both existing test directories are already collected by `fiber.yml`.
