### PR TITLE
ci: add PR1466 rapid reconnect soak workflow

### DIFF
--- a/.github/workflows/fiber-pr1466-reconnect-soak.yml
+++ b/.github/workflows/fiber-pr1466-reconnect-soak.yml
@@ -1,0 +1,182 @@
+name: Fiber PR1466 rapid reconnect soak
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Number of isolated test iterations
+        required: true
+        default: 30
+        type: number
+      fiber_url:
+        description: Fiber source repository
+        required: true
+        default: https://github.com/nervosnetwork/fiber.git
+        type: string
+      fiber_ref:
+        description: Fiber branch or tag to test
+        required: true
+        default: develop
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fiber-pr1466-reconnect-soak-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TEST_TARGET: test_cases/fiber/devnet/send_payment/offline/test_pr1466_reestablish_retry.py::TestPR1466ReestablishRetry::test_pending_payments_finish_after_rapid_reconnects
+
+jobs:
+  reconnect-soak:
+    name: Run rapid reconnect test ${{ inputs.runs }} times
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out integration tests
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate iteration count
+        env:
+          RUNS: ${{ inputs.runs }}
+        run: |
+          if ! [[ "$RUNS" =~ ^[0-9]+$ ]] || (( RUNS < 1 || RUNS > 100 )); then
+            echo "runs must be an integer between 1 and 100; received: $RUNS" >&2
+            exit 2
+          fi
+
+      - name: Prepare CKB and Fiber
+        env:
+          GitUrl: ${{ inputs.fiber_url }}
+          GitBranch: ${{ inputs.fiber_ref }}
+        run: make prepare
+
+      - name: Bind test runtime to selected Fiber build
+        run: |
+          selected_bin="download/fiber/current/fnn"
+          runtime_bin="$({
+            ./venv/bin/python - <<'PY'
+          from framework.test_fiber import FiberConfigPath
+          print(FiberConfigPath.CURRENT_DEV.fiber_bin_path)
+          PY
+          } | tail -n 1)"
+
+          test -x "$selected_bin"
+          if [[ "$runtime_bin" != "$selected_bin" ]]; then
+            mkdir -p "$(dirname "$runtime_bin")"
+            install -m 0755 "$selected_bin" "$runtime_bin"
+          fi
+          cmp "$selected_bin" "$runtime_bin"
+          echo "runtime_bin=$runtime_bin" >> "$GITHUB_ENV"
+
+      - name: Record test environment
+        run: |
+          mkdir -p soak-artifacts
+
+          {
+            echo "integration_commit=$(git rev-parse HEAD)"
+            echo "fiber_url=${{ inputs.fiber_url }}"
+            echo "fiber_ref=${{ inputs.fiber_ref }}"
+            echo "fiber_commit=$(git -C fiber rev-parse HEAD)"
+            echo "fnn_binary=$runtime_bin"
+            echo "fnn_sha256=$(sha256sum "$runtime_bin" | awk '{print $1}')"
+            if [[ -x "$runtime_bin" ]]; then
+              "$runtime_bin" --version
+            else
+              echo "FNN binary is missing or is not executable"
+            fi
+            ./venv/bin/python --version
+            uname -a
+          } | tee soak-artifacts/environment.txt
+
+      - name: Run isolated soak iterations
+        id: soak
+        env:
+          RUNS: ${{ inputs.runs }}
+        run: |
+          set -u -o pipefail
+
+          passed=0
+          failed=0
+          printf 'iteration\tstatus\texit_code\tduration_seconds\n' \
+            > soak-artifacts/results.tsv
+
+          for ((iteration = 1; iteration <= RUNS; iteration++)); do
+            run_id="$(printf '%03d' "$iteration")"
+            run_dir="soak-artifacts/run-$run_id"
+            mkdir -p "$run_dir"
+            rm -rf report
+
+            echo "::group::Iteration $iteration/$RUNS"
+            started_at="$(date +%s)"
+            set +e
+            ./venv/bin/python -u -m pytest \
+              -vv -s --tb=short \
+              -o log_cli_level=INFO \
+              -o 'addopts=' \
+              "$TEST_TARGET" 2>&1 | tee "$run_dir/pytest.log"
+            pytest_status="${PIPESTATUS[0]}"
+            set -e
+            duration="$(( $(date +%s) - started_at ))"
+
+            if (( pytest_status == 0 )); then
+              status=PASS
+              passed="$((passed + 1))"
+            else
+              status=FAIL
+              failed="$((failed + 1))"
+              if [[ -d report ]]; then
+                cp -a report "$run_dir/report"
+              fi
+              if [[ -d tmp ]]; then
+                cp -a tmp "$run_dir/tmp-fallback"
+              fi
+            fi
+
+            printf '%s\t%s\t%s\t%s\n' \
+              "$iteration" "$status" "$pytest_status" "$duration" \
+              >> soak-artifacts/results.tsv
+            echo "Iteration $iteration/$RUNS: $status (${duration}s)"
+            echo "::endgroup::"
+          done
+
+          {
+            echo "# Fiber PR1466 rapid reconnect soak"
+            echo
+            echo "| Result | Count |"
+            echo "|---|---:|"
+            echo "| Requested | $RUNS |"
+            echo "| Passed | $passed |"
+            echo "| Failed | $failed |"
+            echo
+            echo "Test: \`$TEST_TARGET\`"
+          } | tee soak-artifacts/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+          echo "passed=$passed" >> "$GITHUB_OUTPUT"
+          echo "failures=$failed" >> "$GITHUB_OUTPUT"
+
+      - name: Upload soak evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fiber-pr1466-reconnect-soak-${{ github.run_id }}-${{ github.run_attempt }}
+          path: soak-artifacts
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Fail when any iteration failed
+        if: steps.soak.outputs.failures != '0'
+        env:
+          FAILURES: ${{ steps.soak.outputs.failures }}
+          PASSED: ${{ steps.soak.outputs.passed }}
+        run: |
+          echo "$FAILURES soak iteration(s) failed; $PASSED passed." >&2
+          exit 1


### PR DESCRIPTION
## Summary

- add a manually triggered GitHub Actions soak workflow for the PR1466 rapid reconnect regression test
- run the exact pytest node in an isolated process for a configurable number of iterations (default 30, range 1–100)
- build the requested Fiber branch/tag once and bind the test runtime to that selected binary
- continue after individual failures, upload per-iteration logs and reports, then fail the job if any iteration failed

## Why

The rapid reconnect/reestablish payment test has failed intermittently in GitHub Actions while remaining difficult to reproduce locally. A repeatable CI soak job provides integration confidence and preserves the node logs from the exact failing iteration.

## Validation

- parsed the workflow YAML and checked all six shell blocks with `bash -n`
- simulated three all-pass iterations: `pass=3 fail=0 continued=3`
- simulated a failure in iteration 2: `pass=2 fail=1 continued=3`
- verified the final failure gate exits with status 1
- collected the exact pytest node successfully: `1 test collected`
