### PR TITLE
ci: install soak dependencies in virtualenv

### DIFF
--- a/.github/workflows/fiber-pr1466-reconnect-soak.yml
+++ b/.github/workflows/fiber-pr1466-reconnect-soak.yml
@@ -57,7 +57,12 @@ jobs:
         env:
           GitUrl: ${{ inputs.fiber_url }}
           GitBranch: ${{ inputs.fiber_ref }}
-        run: make prepare
+        run: |
+          make prepare
+          # Make recipes run each line in a separate shell, so their activate
+          # command does not install requirements into this virtualenv.
+          ./venv/bin/python -m pip install --upgrade pip
+          ./venv/bin/python -m pip install -r requirements.txt
 
       - name: Bind test runtime to selected Fiber build
         run: |


### PR DESCRIPTION
## Summary

- install the integration-test requirements with `./venv/bin/python` after `make prepare`
- ensure the following runtime-binding and pytest steps use a virtualenv containing PyYAML and the rest of the test dependencies

## Root cause

Follow-up to #95. The `prepare` Make recipe activates the virtualenv on one recipe line, but every subsequent line runs in a separate shell. Its `python3 -m pip` and `pip install` commands therefore install into the setup Python instead of the generated `venv`.

The soak workflow then imports `framework.test_fiber` with `./venv/bin/python`. That import reaches `framework.helper.ckb_cli`, fails with `ModuleNotFoundError: No module named 'yaml'`, leaves `runtime_bin` empty, and causes the following `install` command to fail as well.

## Validation

- workflow YAML and all six shell blocks validated
- virtualenv import check passed with `PyYAML=6.0.1` and `pytest=7.3.2`
- all-pass loop simulation: `pass=3 fail=0 continued=3`
- middle-failure simulation: `pass=2 fail=1 continued=3`
- final failure gate exits with status 1
- exact PR1466 pytest node collected successfully: `1 test collected`
