### PR TITLE
test: stabilize shutdown channel checks after force restart

### DIFF
--- a/test_cases/fiber/devnet/shutdown_channel/test_force_restart.py
+++ b/test_cases/fiber/devnet/shutdown_channel/test_force_restart.py
@@ -77,6 +77,14 @@ class TestForceRestart(FiberTest):
         assert result["status"] == "unknown"
         print(f"result=:{result}")
         # 2.检查channel被close成功
+        self.wait_for_channel_state(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            "Closed",
+            120,
+            include_closed=True,
+            channel_id=N1N2_CHANNEL_ID,
+        )
         node_info = self.fiber1.get_client().node_info()
         print("node info :", node_info)
         assert node_info["channel_count"] == "0x0"

--- a/test_cases/fiber/devnet/shutdown_channel/test_restart.py
+++ b/test_cases/fiber/devnet/shutdown_channel/test_restart.py
@@ -167,6 +167,14 @@ class TestRestart(FiberTest):
         assert result["status"] == "unknown"
         print(f"result=:{result}")
         # 2.检查channel被close成功
+        self.wait_for_channel_state(
+            self.fiber1.get_client(),
+            self.fiber2.get_pubkey(),
+            "Closed",
+            120,
+            include_closed=True,
+            channel_id=N1N2_CHANNEL_ID,
+        )
         node_info = self.fiber1.get_client().node_info()
         print("node info :", node_info)
         assert node_info["channel_count"] == "0x0"


### PR DESCRIPTION
## Summary
- wait for the exact channel to reach `Closed` after force-restarting Fiber nodes
- include closed channels while polling before asserting `node_info.channel_count == "0x0"`
- apply the same synchronization to both force-restart shutdown regression tests

## Why
The funding cell can already be spent while the restarted Fiber node still temporarily reports `channel_count == "0x1"`. Waiting for channel state reconciliation removes that timing race.

## Testing
- `test_cases/fiber/devnet/shutdown_channel/test_force_restart.py::TestForceRestart::test_force_restart_fiber_node_shutdown_channel` — passed
- `test_cases/fiber/devnet/shutdown_channel/test_restart.py::TestRestart::test_force_restart_fiber_node_shutdown_channel` — passed
- Python compilation, pytest collection, and `git diff --check` — passed
