### PR TITLE
test: add attack FNN regressions and CI

### DIFF
--- a/.github/workflows/fiber-attack-fnn.yml
+++ b/.github/workflows/fiber-attack-fnn.yml
@@ -23,9 +23,9 @@ on:
         default: https://github.com/nervosnetwork/fiber.git
         type: string
       stock_fiber_ref:
-        description: Commit used to build the unmodified FNN
+        description: Branch used to build the unmodified FNN
         required: true
-        default: f9232d52254a5aa52195ecae296c896de7078887
+        default: develop
         type: string
       attack_fiber_repository:
         description: Repository containing the debug attack RPCs
@@ -33,9 +33,9 @@ on:
         default: https://github.com/gpBlockchain/fiber.git
         type: string
       attack_fiber_ref:
-        description: Commit used to build the instrumented FNN
+        description: Branch used to build the instrumented FNN
         required: true
-        default: 48a68f72ac63f46ad0bd15fcda030260f026393e
+        default: p2p-tap
         type: string
 
 permissions:
@@ -47,9 +47,9 @@ concurrency:
 
 env:
   STOCK_FIBER_REPOSITORY: ${{ inputs.stock_fiber_repository || 'https://github.com/nervosnetwork/fiber.git' }}
-  STOCK_FIBER_REF: ${{ inputs.stock_fiber_ref || 'f9232d52254a5aa52195ecae296c896de7078887' }}
+  STOCK_FIBER_REF: ${{ inputs.stock_fiber_ref || 'develop' }}
   ATTACK_FIBER_REPOSITORY: ${{ inputs.attack_fiber_repository || 'https://github.com/gpBlockchain/fiber.git' }}
-  ATTACK_FIBER_REF: ${{ inputs.attack_fiber_ref || '48a68f72ac63f46ad0bd15fcda030260f026393e' }}
+  ATTACK_FIBER_REF: ${{ inputs.attack_fiber_ref || 'p2p-tap' }}
 
 jobs:
   attack-fnn-regressions:

--- a/.github/workflows/fiber-attack-fnn.yml
+++ b/.github/workflows/fiber-attack-fnn.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/fiber-attack-fnn.yml"
+      - "download_btc.py"
+      - "download_lnd.py"
       - "framework/attack_fnn.py"
       - "framework/basic_fiber.py"
       - "framework/basic_p2p.py"
@@ -69,6 +71,8 @@ jobs:
           ./venv/bin/python -m pip install --upgrade pip
           ./venv/bin/python -m pip install -r requirements.txt
           ./venv/bin/python -m download
+          ./venv/bin/python -m download_btc
+          ./venv/bin/python -m download_lnd
           install -m 0755 download/0.202.0/ckb-cli source/ckb-cli
 
       - name: Build stock and attack FNN binaries

--- a/.github/workflows/fiber-attack-fnn.yml
+++ b/.github/workflows/fiber-attack-fnn.yml
@@ -1,0 +1,129 @@
+name: Fiber attack FNN regressions
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/fiber-attack-fnn.yml"
+      - "framework/attack_fnn.py"
+      - "framework/basic_fiber.py"
+      - "framework/basic_p2p.py"
+      - "framework/fiber_rpc.py"
+      - "framework/p2p_peer.py"
+      - "framework/test_fiber.py"
+      - "scripts/build_attack_fnn.sh"
+      - "test_cases/fiber/devnet/security/**"
+  workflow_dispatch:
+    inputs:
+      stock_fiber_repository:
+        description: Repository used to build the unmodified FNN
+        required: true
+        default: https://github.com/nervosnetwork/fiber.git
+        type: string
+      stock_fiber_ref:
+        description: Commit used to build the unmodified FNN
+        required: true
+        default: f9232d52254a5aa52195ecae296c896de7078887
+        type: string
+      attack_fiber_repository:
+        description: Repository containing the debug attack RPCs
+        required: true
+        default: https://github.com/gpBlockchain/fiber.git
+        type: string
+      attack_fiber_ref:
+        description: Commit used to build the instrumented FNN
+        required: true
+        default: 48a68f72ac63f46ad0bd15fcda030260f026393e
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fiber-attack-fnn-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  STOCK_FIBER_REPOSITORY: ${{ inputs.stock_fiber_repository || 'https://github.com/nervosnetwork/fiber.git' }}
+  STOCK_FIBER_REF: ${{ inputs.stock_fiber_ref || 'f9232d52254a5aa52195ecae296c896de7078887' }}
+  ATTACK_FIBER_REPOSITORY: ${{ inputs.attack_fiber_repository || 'https://github.com/gpBlockchain/fiber.git' }}
+  ATTACK_FIBER_REF: ${{ inputs.attack_fiber_ref || '48a68f72ac63f46ad0bd15fcda030260f026393e' }}
+
+jobs:
+  attack-fnn-regressions:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out integration tests
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies and node runtimes
+        run: |
+          python -m venv venv
+          ./venv/bin/python -m pip install --upgrade pip
+          ./venv/bin/python -m pip install -r requirements.txt
+          ./venv/bin/python -m download
+          install -m 0755 download/0.202.0/ckb-cli source/ckb-cli
+
+      - name: Build stock and attack FNN binaries
+        env:
+          FIBER_BUILD_DIR: ${{ runner.temp }}/fiber-attack-build
+        run: ./scripts/build_attack_fnn.sh
+
+      - name: Verify binary roles and provenance
+        run: |
+          set -euo pipefail
+          test -x download/fiber/current/fnn
+          test -x download/fiber/attack/fnn
+          test -s download/fiber/provenance.env
+
+          if grep -aFq set_fiber_message_intercept download/fiber/current/fnn; then
+            echo "stock FNN unexpectedly exposes attack RPCs" >&2
+            exit 1
+          fi
+          grep -aFq set_fiber_message_intercept download/fiber/attack/fnn
+          grep -aFq send_raw_channel_message download/fiber/attack/fnn
+
+          cat download/fiber/provenance.env
+
+      - name: Run tests marked requires_attack_fnn
+        run: |
+          set -euo pipefail
+          mkdir -p attack-fnn-artifacts
+          cp download/fiber/provenance.env attack-fnn-artifacts/
+          ./venv/bin/python -m pytest \
+            -o addopts= \
+            --strict-markers \
+            -vv -s --tb=short \
+            --junitxml=attack-fnn-artifacts/junit.xml \
+            -m requires_attack_fnn \
+            test_cases/fiber/devnet/security \
+            2>&1 | tee attack-fnn-artifacts/pytest.log
+
+      - name: Publish source provenance
+        if: always()
+        run: |
+          if [[ -f download/fiber/provenance.env ]]; then
+            {
+              echo "```text"
+              cat download/fiber/provenance.env
+              echo "```"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload attack FNN evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fiber-attack-fnn-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            attack-fnn-artifacts
+            report
+          if-no-files-found: warn
+          retention-days: 14

--- a/download_btc.py
+++ b/download_btc.py
@@ -19,17 +19,17 @@ DOWNLOAD_DIR = "download/btc"
 SYSTEMS = {
     "Linux": {
         "x86_64": {
-            "url": " https://bitcoincore.org/bin/bitcoin-core-{version}/bitcoin-{version}-x86_64-linux-gnu.tar.gz",
+            "url": "https://bitcoincore.org/bin/bitcoin-core-{version}/bitcoin-{version}-x86_64-linux-gnu.tar.gz",
             "ext": ".tar.gz",
         },
     },
     "Darwin": {
         "x86_64": {
-            "url": " https://bitcoincore.org/bin/bitcoin-core-{version}/bitcoin-{version}-x86_64-apple-darwin.tar.gz",
+            "url": "https://bitcoincore.org/bin/bitcoin-core-{version}/bitcoin-{version}-x86_64-apple-darwin.tar.gz",
             "ext": ".tar.gz",
         },
         "arm64": {
-            "url": " https://bitcoincore.org/bin/bitcoin-core-{version}/bitcoin-{version}-x86_64-apple-darwin.tar.gz",
+            "url": "https://bitcoincore.org/bin/bitcoin-core-{version}/bitcoin-{version}-x86_64-apple-darwin.tar.gz",
             "ext": ".tar.gz",
         },
     },

--- a/framework/attack_fnn.py
+++ b/framework/attack_fnn.py
@@ -1,0 +1,18 @@
+"""Shared marker and path for tests that need the instrumented FNN."""
+
+import os
+
+import pytest
+
+from framework.util import get_project_root
+
+ATTACK_FNN = os.path.join(get_project_root(), "download/fiber/attack/fnn")
+
+
+def requires_attack_fnn(test_item):
+    """Select the test for attack-FNN CI and skip when its binary is absent."""
+    test_item = pytest.mark.requires_attack_fnn(test_item)
+    return pytest.mark.skipif(
+        not (os.path.isfile(ATTACK_FNN) and os.access(ATTACK_FNN, os.X_OK)),
+        reason=f"executable attack fnn not found at {ATTACK_FNN}",
+    )(test_item)

--- a/framework/basic_fiber.py
+++ b/framework/basic_fiber.py
@@ -13,6 +13,7 @@ from framework.util import to_int_from_big_uint128_le, change_time
 import logging
 import os
 import subprocess
+import framework.config as framework_config
 
 # FIBER_TAR_GZ = "ckb-py-integration-test/source/fiber/data.fiber.tar.gz"
 XUDT_TX_HASH = "0x03c4475655a46dc4984c49fce03316f80bf666236bd95118112731082758d686"
@@ -36,6 +37,18 @@ class FiberTest(CkbTest):
     fnn_log_level = "debug"
     beginNum = "0x0"
     node: CkbTest.CkbNode
+    # Override these in a suite that must run beside another local devnet.
+    tmp_path_name = None
+    ckb_rpc_port = 8114
+    ckb_p2p_port = 8125
+    fiber1_rpc_port = 8228
+    fiber1_p2p_port = 8227
+    fiber2_rpc_port = 8229
+    fiber2_p2p_port = 8230
+    extra_mock_fiber_rpc_port = 8251
+    extra_mock_fiber_p2p_port = 8302
+    extra_fiber_rpc_port = 8251
+    extra_fiber_p2p_port = 8402
 
     @classmethod
     def setup_class(cls):
@@ -46,6 +59,10 @@ class FiberTest(CkbTest):
         Returns:
 
         """
+        cls._original_tmp_path_name = framework_config.TMP_PATH
+        if cls.tmp_path_name is not None:
+            framework_config.TMP_PATH = cls.tmp_path_name
+
         global ACCOUNT_PRIVATE_KEY_INDEX
         ACCOUNT_PRIVATE_KEY_INDEX = 0
         cls.account1_private_key = cls.Config.ACCOUNT_PRIVATE_1
@@ -57,11 +74,14 @@ class FiberTest(CkbTest):
             cls.account2_private_key
         )
         cls.node = cls.CkbNode.init_dev_by_port(
-            cls.CkbNodeConfigPath.CURRENT_TEST, "contract/node", 8114, 8125
+            cls.CkbNodeConfigPath.CURRENT_TEST,
+            "contract/node",
+            cls.ckb_rpc_port,
+            cls.ckb_p2p_port,
         )
 
         if cls.debug:
-            if check_port(8114):
+            if check_port(cls.ckb_rpc_port):
                 cls.logger.debug("=====不是第一次启动=====")
                 return
             cls.debug = False
@@ -95,15 +115,15 @@ class FiberTest(CkbTest):
             self.fiber_version,
             self.account1_private_key,
             "fiber/node1",
-            "8228",
-            "8227",
+            str(self.fiber1_rpc_port),
+            str(self.fiber1_p2p_port),
         )
         self.fiber2 = Fiber.init_by_port(
             self.fiber_version,
             self.account2_private_key,
             "fiber/node2",
-            "8229",
-            "8230",
+            str(self.fiber2_rpc_port),
+            str(self.fiber2_p2p_port),
         )
         self.fibers.append(self.fiber1)
         self.fibers.append(self.fiber2)
@@ -165,12 +185,14 @@ class FiberTest(CkbTest):
 
     @classmethod
     def teardown_class(cls):
-        if cls.debug:
-            return
-        if cls.first_debug:
-            return
-        cls.node.stop()
-        cls.node.clean()
+        try:
+            if cls.debug or cls.first_debug:
+                return
+            cls.node.stop()
+            cls.node.clean()
+        finally:
+            if cls.tmp_path_name is not None:
+                framework_config.TMP_PATH = cls._original_tmp_path_name
 
     def faucet(
         self,
@@ -224,8 +246,8 @@ class FiberTest(CkbTest):
             fiber_version,
             account_private_key,
             f"fiber/node{3 + i}",
-            str(8251 + i),
-            str(8302 + i),
+            str(self.extra_mock_fiber_rpc_port + i),
+            str(self.extra_mock_fiber_p2p_port + i),
         )
         fiber.read_ckb_key()
         self.new_fibers.append(fiber)
@@ -261,8 +283,8 @@ class FiberTest(CkbTest):
             fiber_version,
             account_private_key,
             f"fiber/node{3 + i}",
-            str(8251 + i),
-            str(8402 + i),
+            str(self.extra_fiber_rpc_port + i),
+            str(self.extra_fiber_p2p_port + i),
         )
         self.fibers.append(fiber)
         self.new_fibers.append(fiber)

--- a/framework/basic_p2p.py
+++ b/framework/basic_p2p.py
@@ -1,0 +1,275 @@
+"""Base class for P2P fault-injection scenarios.
+
+Each test method gets:
+
+- ``self.victim``: stock ``download/fiber/current/fnn`` (no Dev intercept)
+- ``self.attacker``: debug ``download/fiber/attack/fnn``
+- ``self.peer``: ``P2pPeer`` bound to the attacker
+- ``self.channel_id``: a ChannelReady channel (unless ``auto_open_channel``
+  is set to False)
+
+Write a new scenario like this::
+
+    from framework.basic_p2p import P2pFiberTest
+
+    class TestDelayAddTlc(P2pFiberTest):
+        def test_delay_inbound_add_tlc(self):
+            self.peer.intercept(self.channel_id, capture_in=["AddTlc"])
+            self.send_payment(
+                self.victim, self.attacker, 1 * 100000000, wait=False
+            )
+            self.peer.wait_deliver("AddTlc")
+"""
+
+from __future__ import annotations
+
+import time
+
+from framework.attack_fnn import requires_attack_fnn
+from framework.basic_fiber import FiberTest
+from framework.config import DEFAULT_MIN_DEPOSIT_CKB
+from framework.p2p_peer import P2pPeer, hex_int
+from framework.test_fiber import Fiber, FiberConfigPath
+
+SECP256K1_BLAKE160_CODE_HASH = (
+    "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"
+)
+
+
+@requires_attack_fnn
+class P2pFiberTest(FiberTest):
+    """Honest current victim + debug attacker, optional ready channel."""
+
+    fiber_version = FiberConfigPath.CURRENT_DEV
+    auto_open_channel = True
+    # Keep P2P fault-injection suites independent from the default devnet
+    # ports and its on-disk stores, so a focused run has no cross-suite locks.
+    tmp_path_name = "tmp-p2p"
+    ckb_rpc_port = 18114
+    ckb_p2p_port = 18125
+    fiber1_rpc_port = 18228
+    fiber1_p2p_port = 18227
+    fiber2_rpc_port = 18229
+    fiber2_p2p_port = 18230
+    extra_fiber_rpc_port = 18251
+    extra_fiber_p2p_port = 18402
+    fnn_log_level = "error"
+    attacker_auto_accept = True
+    channel_local_balance = 200 * 100000000
+    channel_remote_balance = 0
+
+    victim: Fiber
+    attacker: Fiber
+    peer: P2pPeer
+    channel_id: str | None
+    temporary_channel_id: str | None
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.victim = self.fiber1
+        # P2P cases use the stock victim plus the debug attacker.  The second
+        # stock node created by FiberTest is not part of this topology; release
+        # it before starting the attacker so focused fault-injection runs stay
+        # within the local process budget.
+        spare_fiber = self.fiber2
+        spare_fiber.force_stop()
+        spare_fiber.clean()
+        self.fibers.remove(spare_fiber)
+        if not self.attacker_auto_accept:
+            self.start_fiber_config = {
+                **getattr(self, "start_fiber_config", {}),
+                "fiber_open_channel_auto_accept_min_ckb_funding_amount": hex(10**18),
+            }
+        self.attacker = self.start_new_fiber(
+            self.generate_account(10000),
+            fiber_version=FiberConfigPath.ATTACK_DEV,
+        )
+        self.peer = P2pPeer(self.attacker)
+        self.channel_id = None
+        self.temporary_channel_id = None
+        if self.auto_open_channel:
+            self.open_ready_channel()
+
+    def open_ready_channel(self, local=None, remote=None):
+        self.channel_id = self.open_channel(
+            self.victim,
+            self.attacker,
+            self.channel_local_balance if local is None else local,
+            self.channel_remote_balance if remote is None else remote,
+        )
+        return self.channel_id
+
+    def propose_channel(self, local=None, public=True):
+        """Victim sends OpenChannel and returns the temporary channel id."""
+        amount = self.channel_local_balance if local is None else local
+        self.victim.connect_peer(self.attacker)
+        result = self.victim.get_client().open_channel(
+            {
+                "pubkey": self.attacker.get_pubkey(),
+                "funding_amount": hex(amount + DEFAULT_MIN_DEPOSIT_CKB),
+                "public": public,
+            }
+        )
+        self.temporary_channel_id = result["temporary_channel_id"]
+        return self.temporary_channel_id
+
+    def accept_proposed(self, temp_id=None, remote=None):
+        """Attacker answers AcceptChannel. Set intercept on temp_id first."""
+        temp_id = temp_id or self.temporary_channel_id
+        amount = self.channel_remote_balance if remote is None else remote
+        return self.attacker.get_client().accept_channel(
+            {
+                "temporary_channel_id": temp_id,
+                "funding_amount": hex(amount + DEFAULT_MIN_DEPOSIT_CKB),
+            }
+        )
+
+    def wait_ready(self, timeout=180):
+        self.channel_id = self.wait_for_channel_state(
+            self.victim.get_client(),
+            self.attacker.get_pubkey(),
+            "ChannelReady",
+            timeout=timeout,
+        )
+        return self.channel_id
+
+    def pay(self, amount=1 * 100000000, wait=False):
+        """Victim pays attacker. Default is async so you can intercept."""
+        return self.send_payment(self.victim, self.attacker, amount, wait=wait)
+
+    def start_observer(self):
+        """A third stock node used to watch gossip / graph broadcast."""
+        observer = self.start_new_fiber(
+            self.generate_account(1000),
+            fiber_version=FiberConfigPath.CURRENT_DEV,
+        )
+        observer.connect_peer(self.victim)
+        return observer
+
+    def wait_graph_channel(self, fiber, timeout=90):
+        """Wait until ``fiber``'s graph sees the victim-attacker channel."""
+        left = self.victim.get_pubkey()
+        right = self.attacker.get_pubkey()
+        deadline = time.time() + timeout
+        last = []
+        while time.time() < deadline:
+            last = fiber.get_client().graph_channels().get("channels") or []
+            for channel in last:
+                nodes = {channel.get("node1"), channel.get("node2")}
+                if left in nodes and right in nodes:
+                    return channel
+            time.sleep(1)
+        raise TimeoutError(
+            f"graph on {fiber.client.url} never saw {left}--{right}; last={last}"
+        )
+
+    def channel_of(self, fiber, include_closed=True):
+        channels = fiber.get_client().list_channels({"include_closed": include_closed})[
+            "channels"
+        ]
+        wanted = [item for item in (self.channel_id, self.temporary_channel_id) if item]
+        for channel in channels:
+            if channel["channel_id"] in wanted:
+                return channel
+        if wanted:
+            raise AssertionError(f"channel {wanted} not found on {fiber.client.url}")
+        if channels:
+            return channels[0]
+        raise AssertionError(f"no channel on {fiber.client.url}")
+
+    def channel_state(self, fiber, include_closed=True):
+        return self.channel_of(fiber, include_closed=include_closed)["state"][
+            "state_name"
+        ]
+
+    def wait_channel_state(self, fiber, expected, timeout=30, include_closed=True):
+        deadline = time.time() + timeout
+        last = None
+        expected_states = (expected,) if isinstance(expected, str) else tuple(expected)
+        while time.time() < deadline:
+            try:
+                last = self.channel_state(fiber, include_closed=include_closed)
+            except AssertionError:
+                last = None
+            if last in expected_states:
+                return last
+            time.sleep(0.2)
+        raise TimeoutError(
+            f"channel {self.channel_id} state {last!r} != {expected_states}"
+        )
+
+    def close_script(self, fiber):
+        return {
+            "code_hash": SECP256K1_BLAKE160_CODE_HASH,
+            "hash_type": "type",
+            "args": fiber.get_account()["lock_arg"],
+        }
+
+    def rpc_shutdown(self, fiber, force=False, fee_rate=1000):
+        params = {"channel_id": self.channel_id}
+        if force:
+            params["force"] = True
+        else:
+            params["close_script"] = self.close_script(fiber)
+            params["fee_rate"] = hex(fee_rate)
+        return fiber.get_client().shutdown_channel(params)
+
+    def disconnect_peers(self):
+        self.victim.get_client().disconnect_peer({"pubkey": self.attacker.get_pubkey()})
+
+    def reconnect_peers(self):
+        self.victim.connect_peer(self.attacker)
+
+    @staticmethod
+    def hex_int(value):
+        return hex_int(value)
+
+
+class P2pRouterTest(P2pFiberTest):
+    """Two stock nodes plus a debug router in the middle.
+
+    Alice (current/fnn) -- Router (attack/fnn) -- Bob (current/fnn)
+
+    The router sees Alice's P2P messages as inbound on ``ch_alice`` and
+    Bob's as inbound on ``ch_bob``. Intercept either leg independently.
+    """
+
+    auto_open_channel = False
+
+    alice: Fiber
+    router: Fiber
+    bob: Fiber
+    ch_alice: str
+    ch_bob: str
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.alice = self.victim
+        self.router = self.attacker
+        self.bob = self.start_new_fiber(
+            self.generate_account(10000),
+            fiber_version=FiberConfigPath.CURRENT_DEV,
+        )
+        self.ch_alice = self.open_channel(self.alice, self.router, 200 * 100000000, 0)
+        self.bob.connect_peer(self.router)
+        self.ch_bob = self.open_channel(self.router, self.bob, 200 * 100000000, 0)
+        self.channel_id = self.ch_alice
+        self.wait_graph_channels_sync(self.alice, 2, timeout=90)
+        self.wait_graph_channels_sync(self.bob, 2, timeout=90)
+
+    def intercept_alice(self, **kwargs):
+        return self.peer.intercept(self.ch_alice, **kwargs)
+
+    def intercept_bob(self, **kwargs):
+        return self.peer.intercept(self.ch_bob, **kwargs)
+
+    def pay_alice_to_bob(self, amount=1 * 100000000, wait=False):
+        return self.send_payment(self.alice, self.bob, amount, wait=wait)
+
+    def message_from(self, message):
+        pubkey = message.get("peer_pubkey") or ""
+        if pubkey == self.alice.get_pubkey():
+            return "alice"
+        if pubkey == self.bob.get_pubkey():
+            return "bob"
+        return "router"

--- a/framework/fiber_rpc.py
+++ b/framework/fiber_rpc.py
@@ -217,6 +217,33 @@ class FiberRPCClient:
         """Individual send/receive payment events. See fiber-json-types fee::PaymentHistoryParams."""
         return self.call("payment_history", [param])
 
+    def commitment_signed(self, param):
+        return self.call("commitment_signed", [param])
+
+    def set_fiber_message_intercept(self, param):
+        return self.call("set_fiber_message_intercept", [param])
+
+    def take_captured_fiber_messages(self):
+        return self.call("take_captured_fiber_messages", [])
+
+    def deliver_captured_fiber_messages(self, param={}):
+        return self.call("deliver_captured_fiber_messages", [param])
+
+    def take_held_outbound_fiber_messages(self):
+        return self.call("take_held_outbound_fiber_messages", [])
+
+    def release_held_outbound_fiber_messages(self, param={}):
+        return self.call("release_held_outbound_fiber_messages", [param])
+
+    def send_raw_channel_message(self, param):
+        return self.call("send_raw_channel_message", [param])
+
+    def get_channel_musig2_public(self, param):
+        return self.call("get_channel_musig2_public", [param])
+
+    def build_shutdown_tx_message(self, param):
+        return self.call("build_shutdown_tx_message", [param])
+
     def node_info(self):
         """
         curl --location 'http://127.0.0.1:8229' --header 'Content-Type: application/json' --data '{

--- a/framework/p2p_peer.py
+++ b/framework/p2p_peer.py
@@ -1,0 +1,342 @@
+"""P2P fault-injection driver for the attack/debug fnn.
+
+Wraps the debug Dev RPCs so tests can drop, capture, delay, and inject
+Fiber channel messages without touching the honest victim.
+
+Prefer ``P2pFiberTest`` in ``framework.basic_p2p`` when writing a new
+scenario: it already starts ``current/fnn`` as victim and ``attack/fnn``
+as this peer, then opens a ready channel.
+
+Typical use:
+
+    peer = P2pPeer(attacker_fiber)
+    peer.intercept(
+        channel_id,
+        capture_in=["RevokeAndAck", "CommitmentSigned"],
+        drop_out=["RevokeAndAck"],
+    )
+    peer.send_cs(channel_id)
+    peer.wait_deliver("RevokeAndAck")
+
+Queue rules (easy to get wrong):
+
+- ``wait()`` / ``take()`` drain the inbound capture queue. Do not call
+  them if you still want ``deliver()`` / ``wait_deliver()`` later.
+- ``wait_held()`` / ``take_held()`` drain the outbound hold queue. Do
+  not call them if you still want ``release_held()`` / ``wait_release()``.
+- ``send_raw`` and the ``send_*`` helpers bypass intercept on the way
+  out, so a held/dropped kind can still be injected.
+
+Kind names accept ``CommitmentSigned`` or ``commitment_signed``.
+"""
+
+from __future__ import annotations
+
+import time
+
+from framework.fiber_rpc import FiberRPCClient
+from framework.test_fiber import Fiber
+
+# Names match FiberChannelMessage Display / intercept matching.
+# All-zero id: intercept every channel (needed while funding still uses a temp id).
+WILDCARD_CHANNEL_ID = "0x" + "00" * 32
+
+# Channel establishment after OpenChannel (BOLT-02-like / docs/specs/p2p-message.md).
+OPEN_CHANNEL_KINDS = (
+    "OpenChannel",
+    "AcceptChannel",
+    "TxUpdate",
+    "TxComplete",
+    "CommitmentSigned",
+    "TxSignatures",
+    "ChannelReady",
+    "AnnouncementSignatures",
+)
+
+CHANNEL_KINDS = (
+    "OpenChannel",
+    "AcceptChannel",
+    "AnnouncementSignatures",
+    "AddTlc",
+    "ChannelReady",
+    "ClosingSigned",
+    "CommitmentSigned",
+    "ReestablishChannel",
+    "RemoveTlc",
+    "RevokeAndAck",
+    "Shutdown",
+    "TxAbort",
+    "TxAckRBF",
+    "TxComplete",
+    "TxInitRBF",
+    "TxSignatures",
+    "TxUpdate",
+    "UpdateTlcInfo",
+)
+
+
+def _hex_u64(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return hex(int(value))
+
+
+def _hex_u128(value):
+    return _hex_u64(value)
+
+
+def hex_int(value):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    return int(value, 16)
+
+
+class P2pPeer:
+    """One attack/debug Fiber node used as a controllable P2P peer."""
+
+    def __init__(self, fiber: Fiber):
+        self.fiber = fiber
+        self.client: FiberRPCClient = fiber.get_client()
+        self._inbox = []
+
+    def intercept(
+        self,
+        channel_id,
+        *,
+        capture_in=None,
+        drop_in=None,
+        drop_out=None,
+        hold_out=None,
+        capture_all_in=False,
+        drop_raa=False,
+    ):
+        """Configure intercept on this peer for one channel.
+
+        Kind names accept ``CommitmentSigned`` or ``commitment_signed``.
+        Passing empty lists clears that action; call ``clear_intercept``
+        to turn everything off.
+        """
+        params = {
+            "channel_id": channel_id,
+            "suppress_outbound_revoke_and_ack": bool(drop_raa),
+            "capture_inbound": bool(capture_all_in),
+            "inbound_capture_kinds": list(capture_in or []),
+            "inbound_drop_kinds": list(drop_in or []),
+            "outbound_drop_kinds": list(drop_out or []),
+            "outbound_hold_kinds": list(hold_out or []),
+        }
+        return self.client.set_fiber_message_intercept(params)
+
+    def clear_intercept(self, channel_id):
+        return self.intercept(channel_id)
+
+    def take(self, kind=None):
+        """Drain captured inbound messages. Optionally keep only ``kind``."""
+        result = self.client.take_captured_fiber_messages() or {}
+        messages = list(result.get("messages") or [])
+        self._inbox.extend(messages)
+        if kind is None:
+            taken = self._inbox
+            self._inbox = []
+            return taken
+        matched = []
+        leftover = []
+        for message in self._inbox:
+            if self._kind_eq(message.get("kind"), kind):
+                matched.append(message)
+            else:
+                leftover.append(message)
+        self._inbox = leftover
+        return matched
+
+    def wait(self, kind, timeout=30):
+        """Block until one captured inbound message of ``kind`` arrives.
+
+        This drains the message from the node. If you later need the
+        channel actor to see it, use ``wait_deliver()`` instead.
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            matched = self.take(kind)
+            if matched:
+                return matched[0]
+            time.sleep(0.2)
+        raise TimeoutError(f"timed out waiting for captured {kind}")
+
+    def deliver(self, count=None, kind=None):
+        """Release captured inbound messages into this node's channel actor."""
+        params = {"kinds": [kind] if kind else []}
+        if count is not None:
+            params["count"] = _hex_u64(count)
+        return self.client.deliver_captured_fiber_messages(params)
+
+    def wait_deliver(self, kind=None, count=1, timeout=30):
+        """Wait until ``count`` captured inbound messages are delivered.
+
+        Polls ``deliver()`` and does not drain via ``take()`` / ``wait()``.
+        """
+        deadline = time.time() + timeout
+        delivered = 0
+        while time.time() < deadline:
+            result = self.deliver(kind=kind)
+            delivered += hex_int(result.get("delivered") or "0x0")
+            if delivered >= count:
+                return delivered
+            time.sleep(0.2)
+        raise TimeoutError(
+            f"timed out delivering {count} captured {kind or 'message'}(s); got {delivered}"
+        )
+
+    def take_held(self):
+        result = self.client.take_held_outbound_fiber_messages() or {}
+        return list(result.get("messages") or [])
+
+    def wait_held(self, kind=None, timeout=30):
+        """Drain the hold queue until a matching outbound message is seen.
+
+        Consumes the queue. Use ``wait_release()`` if the peer should
+        still receive the message later.
+        """
+        deadline = time.time() + timeout
+        leftover = []
+        while time.time() < deadline:
+            leftover.extend(self.take_held())
+            if kind is None:
+                if leftover:
+                    taken = leftover
+                    leftover = []
+                    return taken
+            else:
+                matched = [
+                    message
+                    for message in leftover
+                    if self._kind_eq(message.get("kind"), kind)
+                ]
+                leftover = [
+                    message
+                    for message in leftover
+                    if not self._kind_eq(message.get("kind"), kind)
+                ]
+                if matched:
+                    return matched
+            time.sleep(0.2)
+        raise TimeoutError(f"timed out waiting for held {kind or 'message'}")
+
+    def release_held(self, count=None, kind=None):
+        params = {"kinds": [kind] if kind else []}
+        if count is not None:
+            params["count"] = _hex_u64(count)
+        return self.client.release_held_outbound_fiber_messages(params)
+
+    def wait_release(self, kind=None, count=1, timeout=30):
+        """Wait until ``count`` held outbound messages are sent to the peer."""
+        deadline = time.time() + timeout
+        released = 0
+        while time.time() < deadline:
+            result = self.release_held(kind=kind)
+            released += hex_int(result.get("released") or "0x0")
+            if released >= count:
+                return released
+            time.sleep(0.2)
+        raise TimeoutError(
+            f"timed out releasing {count} held {kind or 'message'}(s); got {released}"
+        )
+
+    def musig2(self, channel_id):
+        return self.client.get_channel_musig2_public({"channel_id": channel_id})
+
+    def send_raw(self, channel_id, kind, **fields):
+        params = {"channel_id": channel_id, "kind": kind}
+        for key, value in fields.items():
+            if value is not None:
+                params[key] = value
+        return self.client.send_raw_channel_message(params)
+
+    def send_cs(
+        self,
+        channel_id,
+        nonce_commitment_number=None,
+        funding_tx_partial_signature=None,
+    ):
+        params = {"channel_id": channel_id, "kind": "commitment_signed"}
+        if nonce_commitment_number is not None:
+            params["nonce_commitment_number"] = _hex_u64(nonce_commitment_number)
+        if funding_tx_partial_signature is not None:
+            params["funding_tx_partial_signature"] = funding_tx_partial_signature
+        return self.client.send_raw_channel_message(params)
+
+    def send_shutdown(self, channel_id, close_script=None, fee_rate=None):
+        params = {"channel_id": channel_id, "kind": "shutdown"}
+        if close_script is not None:
+            params["close_script"] = close_script
+        if fee_rate is not None:
+            params["fee_rate"] = _hex_u64(fee_rate)
+        return self.client.send_raw_channel_message(params)
+
+    def send_add_tlc(
+        self,
+        channel_id,
+        amount=1,
+        payment_hash=None,
+        expiry=None,
+        tlc_id=None,
+    ):
+        params = {
+            "channel_id": channel_id,
+            "kind": "add_tlc",
+            "amount": _hex_u128(amount),
+        }
+        if payment_hash is not None:
+            params["payment_hash"] = payment_hash
+        if expiry is not None:
+            params["expiry"] = _hex_u64(expiry)
+        if tlc_id is not None:
+            params["tlc_id"] = _hex_u64(tlc_id)
+        return self.client.send_raw_channel_message(params)
+
+    def send_remove_tlc(self, channel_id, tlc_id, error_code="TemporaryChannelFailure"):
+        return self.client.send_raw_channel_message(
+            {
+                "channel_id": channel_id,
+                "kind": "remove_tlc",
+                "tlc_id": _hex_u64(tlc_id),
+                "remove_fail_error_code": error_code,
+            }
+        )
+
+    def send_reestablish(self, channel_id, local_cn=None, remote_cn=None):
+        params = {"channel_id": channel_id, "kind": "reestablish_channel"}
+        if local_cn is not None:
+            params["local_commitment_number"] = _hex_u64(local_cn)
+        if remote_cn is not None:
+            params["remote_commitment_number"] = _hex_u64(remote_cn)
+        return self.client.send_raw_channel_message(params)
+
+    def send_tx_abort(self, channel_id, message="p2p-test"):
+        return self.client.send_raw_channel_message(
+            {
+                "channel_id": channel_id,
+                "kind": "tx_abort",
+                "abort_message": message,
+            }
+        )
+
+    def send_closing_signed(self, channel_id, partial_signature):
+        return self.client.send_raw_channel_message(
+            {
+                "channel_id": channel_id,
+                "kind": "closing_signed",
+                "funding_tx_partial_signature": partial_signature,
+            }
+        )
+
+    @staticmethod
+    def _kind_eq(left, right):
+        def normalize(value):
+            return "".join(ch for ch in str(value or "") if ch not in "_-").lower()
+
+        return normalize(left) == normalize(right)

--- a/framework/test_fiber.py
+++ b/framework/test_fiber.py
@@ -57,6 +57,11 @@ class FiberConfigPath(Enum):
         "download/fiber/current/fnn.debug",
     )
 
+    ATTACK_DEV = (
+        "/source/fiber/dev_config_3.yml.j2",
+        "download/fiber/attack/fnn",
+    )
+
     CURRENT_MAINNET = (
         "/source/template/fiber/mainnet_config_3.yml.j2",
         "download/fiber/0.9.0/fnn",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+markers =
+    requires_attack_fnn: requires download/fiber/attack/fnn with debug attack RPCs
 ;ci
 addopts = --html=report/report.html
 ;debug

--- a/scripts/build_attack_fnn.sh
+++ b/scripts/build_attack_fnn.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # Keep the honest node and the instrumented peer on one protocol baseline.
-# Defaults are immutable commits; workflow_dispatch may override them.
+# Defaults follow branches; workflow_dispatch may override either ref.
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 STOCK_FIBER_REPOSITORY="${STOCK_FIBER_REPOSITORY:-https://github.com/nervosnetwork/fiber.git}"
-STOCK_FIBER_REF="${STOCK_FIBER_REF:-f9232d52254a5aa52195ecae296c896de7078887}"
+STOCK_FIBER_REF="${STOCK_FIBER_REF:-develop}"
 ATTACK_FIBER_REPOSITORY="${ATTACK_FIBER_REPOSITORY:-https://github.com/gpBlockchain/fiber.git}"
-ATTACK_FIBER_REF="${ATTACK_FIBER_REF:-48a68f72ac63f46ad0bd15fcda030260f026393e}"
+ATTACK_FIBER_REF="${ATTACK_FIBER_REF:-p2p-tap}"
 FIBER_BUILD_DIR="${FIBER_BUILD_DIR:-$ROOT_DIR/.build/fiber-attack-fnn}"
 PROVENANCE_FILE="${PROVENANCE_FILE:-$ROOT_DIR/download/fiber/provenance.env}"
 

--- a/scripts/build_attack_fnn.sh
+++ b/scripts/build_attack_fnn.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep the honest node and the instrumented peer on one protocol baseline.
+# Defaults are immutable commits; workflow_dispatch may override them.
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+STOCK_FIBER_REPOSITORY="${STOCK_FIBER_REPOSITORY:-https://github.com/nervosnetwork/fiber.git}"
+STOCK_FIBER_REF="${STOCK_FIBER_REF:-f9232d52254a5aa52195ecae296c896de7078887}"
+ATTACK_FIBER_REPOSITORY="${ATTACK_FIBER_REPOSITORY:-https://github.com/gpBlockchain/fiber.git}"
+ATTACK_FIBER_REF="${ATTACK_FIBER_REF:-48a68f72ac63f46ad0bd15fcda030260f026393e}"
+FIBER_BUILD_DIR="${FIBER_BUILD_DIR:-$ROOT_DIR/.build/fiber-attack-fnn}"
+PROVENANCE_FILE="${PROVENANCE_FILE:-$ROOT_DIR/download/fiber/provenance.env}"
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+checkout_ref() {
+    local remote="$1"
+    local ref="$2"
+
+    git -C "$FIBER_BUILD_DIR" fetch --depth=50 "$remote" "$ref"
+    git -C "$FIBER_BUILD_DIR" checkout --detach --force FETCH_HEAD
+    git -C "$FIBER_BUILD_DIR" rev-parse HEAD
+}
+
+build_fnn() {
+    local destination="$1"
+
+    cargo build \
+        --locked \
+        --release \
+        --bin fnn \
+        --manifest-path "$FIBER_BUILD_DIR/Cargo.toml"
+    install -m 0755 "$FIBER_BUILD_DIR/target/release/fnn" "$destination"
+}
+
+mkdir -p "$(dirname "$FIBER_BUILD_DIR")"
+if [[ ! -d "$FIBER_BUILD_DIR/.git" ]]; then
+    git clone --depth=50 --filter=blob:none --no-checkout \
+        "$STOCK_FIBER_REPOSITORY" "$FIBER_BUILD_DIR"
+fi
+
+git -C "$FIBER_BUILD_DIR" remote set-url origin "$STOCK_FIBER_REPOSITORY"
+if git -C "$FIBER_BUILD_DIR" remote get-url attack >/dev/null 2>&1; then
+    git -C "$FIBER_BUILD_DIR" remote set-url attack "$ATTACK_FIBER_REPOSITORY"
+else
+    git -C "$FIBER_BUILD_DIR" remote add attack "$ATTACK_FIBER_REPOSITORY"
+fi
+
+mkdir -p \
+    "$ROOT_DIR/download/fiber/current" \
+    "$ROOT_DIR/download/fiber/attack" \
+    "$(dirname "$PROVENANCE_FILE")"
+
+stock_sha="$(checkout_ref origin "$STOCK_FIBER_REF")"
+build_fnn "$ROOT_DIR/download/fiber/current/fnn"
+
+attack_sha="$(checkout_ref attack "$ATTACK_FIBER_REF")"
+if ! git -C "$FIBER_BUILD_DIR" merge-base --is-ancestor "$stock_sha" "$attack_sha"; then
+    echo "attack FNN commit must descend from stock FNN commit" >&2
+    exit 1
+fi
+build_fnn "$ROOT_DIR/download/fiber/attack/fnn"
+
+stock_hash="$(sha256_file "$ROOT_DIR/download/fiber/current/fnn")"
+attack_hash="$(sha256_file "$ROOT_DIR/download/fiber/attack/fnn")"
+
+cat >"$PROVENANCE_FILE" <<PROVENANCE
+stock_fiber_repository=$STOCK_FIBER_REPOSITORY
+stock_fiber_ref=$STOCK_FIBER_REF
+stock_fiber_sha=$stock_sha
+stock_fnn_sha256=$stock_hash
+attack_fiber_repository=$ATTACK_FIBER_REPOSITORY
+attack_fiber_ref=$ATTACK_FIBER_REF
+attack_fiber_sha=$attack_sha
+attack_base_verified=true
+attack_fnn_sha256=$attack_hash
+PROVENANCE
+
+cat "$PROVENANCE_FILE"

--- a/scripts/build_attack_fnn.sh
+++ b/scripts/build_attack_fnn.sh
@@ -32,12 +32,13 @@ checkout_ref() {
 build_fnn() {
     local destination="$1"
 
+    # The p2p-tap RPC registration is intentionally debug-only. Build the
+    # stock binary with the same profile so behavior differs only by source.
     cargo build \
         --locked \
-        --release \
         --bin fnn \
         --manifest-path "$FIBER_BUILD_DIR/Cargo.toml"
-    install -m 0755 "$FIBER_BUILD_DIR/target/release/fnn" "$destination"
+    install -m 0755 "$FIBER_BUILD_DIR/target/debug/fnn" "$destination"
 }
 
 mkdir -p "$(dirname "$FIBER_BUILD_DIR")"
@@ -75,11 +76,13 @@ cat >"$PROVENANCE_FILE" <<PROVENANCE
 stock_fiber_repository=$STOCK_FIBER_REPOSITORY
 stock_fiber_ref=$STOCK_FIBER_REF
 stock_fiber_sha=$stock_sha
+stock_fnn_profile=debug
 stock_fnn_sha256=$stock_hash
 attack_fiber_repository=$ATTACK_FIBER_REPOSITORY
 attack_fiber_ref=$ATTACK_FIBER_REF
 attack_fiber_sha=$attack_sha
 attack_base_verified=true
+attack_fnn_profile=debug
 attack_fnn_sha256=$attack_hash
 PROVENANCE
 

--- a/test_cases/fiber/devnet/security/test_f0361_cch_receive_btc_inflight.py
+++ b/test_cases/fiber/devnet/security/test_f0361_cch_receive_btc_inflight.py
@@ -1,0 +1,269 @@
+"""F-0361 + CCH regression: LocalAnnounced on-chain fulfill settles LND.
+
+receive_btc is LND in, Fiber out. CCH only calls LND ``settleinvoice`` after
+the Fiber payment reports ``Success`` with a preimage:
+
+    Inflight          -> OutgoingInFlight  -> TrackOutgoingPayment
+    Success+preimage  -> OutgoingSuccess   -> SettleIncomingInvoice
+
+PR #1630 includes offered LocalAnnounced TLCs in on-chain fulfill
+collection, so the CCH origin payment becomes Success after the attacker
+claims P. CCH then settleinvoice; the LND hold invoice must become SETTLED.
+
+Harness
+-------
+fiber1 is stock CURRENT_CCH (hub, PR #1630 fnn). The Fiber payee is
+attack/fnn so we can drop RAA/CS/RemoveTlc, submit the signed commitment,
+and let watchtower claim P.
+"""
+
+import hashlib
+import time
+
+from framework.basic_fiber_with_cch import FiberCchTest
+from framework.attack_fnn import requires_attack_fnn
+from framework.p2p_peer import P2pPeer
+from framework.test_fiber import FiberConfigPath
+
+PAYMENT_AMOUNT_SATS = 100000
+CHANNEL_FUND = 1000 * 100000000
+UDT_FAUCET = 10000 * 100000000
+# Attack fnn defaults to a tiny final expiry that CCH rejects.
+# 9600000 ms is Fiber's minimum and stays under the CCH LND CLTV budget.
+FINAL_EXPIRY_DELTA_MS = 9600000
+
+
+def sha256_hex(preimage_hex):
+    raw = bytes.fromhex(preimage_hex.replace("0x", ""))
+    return "0x" + hashlib.sha256(raw).digest().hex()
+
+
+@requires_attack_fnn
+class TestF0361CchReceiveBtcInflight(FiberCchTest):
+    start_fiber_config = {"fiber_watchtower_check_interval_seconds": 5}
+
+    def _udt_script(self):
+        return self.get_account_udt_script(self.fiber1.account_private)
+
+    def _channel_of(self, fiber):
+        channels = fiber.get_client().list_channels({"include_closed": True})[
+            "channels"
+        ]
+        for channel in channels:
+            if channel["channel_id"] == self.channel_id:
+                return channel
+        raise AssertionError(
+            f"channel {self.channel_id} not found on {fiber.get_client().url}"
+        )
+
+    def _tlc(self, fiber, payment_hash):
+        for tlc in self._channel_of(fiber).get("pending_tlcs") or []:
+            if tlc.get("payment_hash") == payment_hash:
+                return tlc
+        return None
+
+    def _wait_tlc(self, fiber, payment_hash, expected=None, timeout=60):
+        last = None
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            last = self._tlc(fiber, payment_hash)
+            if last is not None and (
+                expected is None or last.get("status") == expected
+            ):
+                return last
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"{fiber.tmp_path} TLC {payment_hash} status {last} != {expected}"
+        )
+
+    def _submit_signed_commitment(self):
+        musig = self.peer.musig2(self.channel_id)
+        numbers = []
+        for key in ("local_commitment_number", "remote_commitment_number"):
+            raw = musig.get(key)
+            if raw is None:
+                continue
+            number = int(raw, 16) if isinstance(raw, str) else int(raw)
+            numbers.extend([number, max(number - 1, 0), number + 1])
+        errors = []
+        tried = set()
+        for number in numbers:
+            if number in tried:
+                continue
+            tried.add(number)
+            try:
+                return self.attacker.get_client().call(
+                    "submit_commitment_transaction",
+                    [
+                        {
+                            "channel_id": self.channel_id,
+                            "commitment_number": hex(number),
+                        }
+                    ],
+                )
+            except Exception as err:
+                errors.append(f"{number}: {err}")
+        raise AssertionError(
+            "attacker could not submit the signed remote commitment: "
+            f"musig={musig} errors={errors}"
+        )
+
+    def _commit_signed_commitment(self, timeout=60):
+        deadline = time.time() + timeout
+        last_error = None
+        while time.time() < deadline:
+            try:
+                submitted = self._submit_signed_commitment()
+                self.Miner.miner_until_tx_committed(self.node, submitted["tx_hash"])
+                return submitted
+            except Exception as error:
+                last_error = error
+                if "Expiry" not in str(error):
+                    raise
+                time.sleep(1)
+        raise TimeoutError(
+            f"signed commitment did not mature within {timeout}s: {last_error}"
+        )
+
+    def _wait_payment_success_with_mining(self, fiber, payment_hash, timeout=180):
+        deadline = time.time() + timeout
+        last = None
+        while time.time() < deadline:
+            last = fiber.get_client().get_payment({"payment_hash": payment_hash})
+            if last["status"] == "Success":
+                return last
+            if last["status"] == "Failed":
+                raise AssertionError(f"payment failed during on-chain settle: {last}")
+            self.Miner.miner_with_version(self.node, "0x0")
+            time.sleep(1)
+        raise TimeoutError(
+            f"payment {payment_hash} did not settle on-chain within {timeout}s: {last}"
+        )
+
+    def _lookup_lnd_invoice(self, payment_hash):
+        return self.LNDs[0].ln_cli_with_cmd(
+            f"lookupinvoice {payment_hash.removeprefix('0x')}"
+        )
+
+    def _lnd_payments(self, payment_hash):
+        target = payment_hash.removeprefix("0x").lower()
+        payments = (
+            self.LNDs[1]
+            .ln_cli_with_cmd("listpayments --include_incomplete")
+            .get("payments", [])
+        )
+        return [
+            payment
+            for payment in payments
+            if payment.get("payment_hash", "").lower() == target
+        ]
+
+    def _start_attack_payee(self):
+        self.attacker = self.start_new_fiber(
+            self.generate_account(
+                10000,
+                self.fiber1.account_private,
+                UDT_FAUCET,
+            ),
+            fiber_version=FiberConfigPath.ATTACK_DEV,
+        )
+        self.peer = P2pPeer(self.attacker)
+        self.fiber1.connect_peer(self.attacker)
+        time.sleep(1)
+        self.channel_id = self.open_channel(
+            self.attacker,
+            self.fiber1,
+            CHANNEL_FUND,
+            CHANNEL_FUND,
+            udt=self._udt_script(),
+        )
+        return self.channel_id
+
+    def _wait_outbound_remote_removed(self, fiber, payment_hash, timeout=90):
+        last = None
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            last = self._tlc(fiber, payment_hash)
+            if last is None:
+                return None
+            if last.get("status") == {"Outbound": "RemoteRemoved"}:
+                return last
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"{fiber.tmp_path} offered TLC {payment_hash} did not "
+            f"reconcile to RemoteRemoved: {last}"
+        )
+
+    def test_receive_btc_localannounced_onchain_settle_settles_lnd(self):
+        """On-chain P settle of a LocalAnnounced CCH payment must settleinvoice."""
+        self._start_attack_payee()
+        preimage = self.generate_random_preimage()
+        payment_hash = sha256_hex(preimage)
+        invoice = self.attacker.get_client().new_invoice(
+            {
+                "amount": hex(PAYMENT_AMOUNT_SATS),
+                "currency": "Fibd",
+                "description": "F-0361 CCH receive_btc LocalAnnounced on-chain settle",
+                "payment_hash": payment_hash,
+                "hash_algorithm": "sha256",
+                "final_expiry_delta": hex(FINAL_EXPIRY_DELTA_MS),
+                "udt_type_script": self._udt_script(),
+            }
+        )
+
+        order = self.fiber1.get_client().receive_btc(
+            {"fiber_pay_req": invoice["invoice_address"]}
+        )
+        assert order["payment_hash"] == payment_hash
+
+        # Arm before LND pays: CCH sends Fiber outgoing as soon as the hold
+        # invoice is accepted. Withhold the ACK that would Commit the TLC.
+        self.peer.intercept(
+            self.channel_id,
+            drop_out=["RevokeAndAck", "CommitmentSigned", "RemoveTlc"],
+            drop_raa=True,
+        )
+
+        self.LNDs[1].ln_cli_with_cmd_without_json(
+            f"payinvoice {order['incoming_invoice']['Lightning']} --force &"
+        )
+        self.wait_cch_order_state(
+            self.fiber1, payment_hash, "OutgoingInFlight", timeout=120
+        )
+        self.wait_payment_state(self.fiber1, payment_hash, "Inflight", timeout=60)
+        cch_tlc = self._wait_tlc(
+            self.fiber1, payment_hash, {"Outbound": "LocalAnnounced"}
+        )
+        attacker_tlc = self._wait_tlc(self.attacker, payment_hash)
+        assert "Inbound" in attacker_tlc.get("status", {}), attacker_tlc
+        assert cch_tlc.get("payment_hash") == payment_hash
+
+        lnd_invoice = self._lookup_lnd_invoice(payment_hash)
+        assert lnd_invoice["state"] == "ACCEPTED", lnd_invoice
+
+        self.attacker.get_client().call(
+            "create_preimage",
+            [{"payment_hash": payment_hash, "preimage": preimage}],
+        )
+        self._commit_signed_commitment()
+        self.node.getClient().generate_epochs("0x1", wait_time=0)
+
+        # PR #1630: LocalAnnounced offered TLC reconciles as fulfilled, so
+        # CCH sees Success+preimage and settleinvoice.
+        payment_after = self._wait_payment_success_with_mining(
+            self.fiber1, payment_hash
+        )
+        assert payment_after.get("payment_preimage") == preimage, payment_after
+
+        cch_tlc = self._wait_outbound_remote_removed(self.fiber1, payment_hash)
+        if cch_tlc is not None:
+            assert cch_tlc["status"] == {"Outbound": "RemoteRemoved"}, cch_tlc
+
+        self.wait_cch_order_state(self.fiber1, payment_hash, "Success", timeout=180)
+
+        lnd_invoice = self._lookup_lnd_invoice(payment_hash)
+        assert lnd_invoice["state"] == "SETTLED", lnd_invoice
+
+        lnd_payments = self._lnd_payments(payment_hash)
+        assert lnd_payments, f"external LND payment missing for {payment_hash}"
+        assert lnd_payments[0]["status"] == "SUCCEEDED", lnd_payments[0]

--- a/test_cases/fiber/devnet/security/test_f0361_localannounced_onchain_reconcile.py
+++ b/test_cases/fiber/devnet/security/test_f0361_localannounced_onchain_reconcile.py
@@ -1,0 +1,197 @@
+"""F-0361 regression: LocalAnnounced offered TLCs reconcile on-chain.
+
+PR #1630
+--------
+An offered TLC that is still ``OutboundTlcStatus::LocalAnnounced`` is already
+inside the signed remote commitment. A peer can withhold RevokeAndAck,
+broadcast that commitment, and spend the TLC on-chain.
+
+On-chain collectors now accept offered ``LocalAnnounced | Committed``, so the
+origin payer learns the fulfill: the TLC is marked RemoteRemoved and the
+payment session becomes Success with the on-chain preimage.
+
+Harness
+-------
+Stock victim is the origin payer. Debug attacker receives AddTlc + CS,
+drops outbound RAA / CS / RemoveTlc so the victim stays LocalAnnounced,
+then submits the signed commitment and lets watchtower claim with P.
+"""
+
+import hashlib
+import time
+
+from framework.basic_p2p import P2pFiberTest
+
+CKB = 100000000
+PAYMENT_AMOUNT = 1 * CKB
+FINAL_EXPIRY_DELTA = 24 * 60 * 60 * 1000
+
+
+def sha256_hex(preimage_hex):
+    raw = bytes.fromhex(preimage_hex.replace("0x", ""))
+    return "0x" + hashlib.sha256(raw).digest().hex()
+
+
+class TestF0361LocalAnnouncedOnchainReconcile(P2pFiberTest):
+    start_fiber_config = {"fiber_watchtower_check_interval_seconds": 5}
+
+    def _tlc(self, fiber, payment_hash):
+        channel = self.channel_of(fiber, include_closed=True)
+        for tlc in channel.get("pending_tlcs") or []:
+            if tlc.get("payment_hash") == payment_hash:
+                return tlc
+        return None
+
+    def _wait_tlc(self, fiber, payment_hash, expected=None, timeout=60):
+        last = None
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            last = self._tlc(fiber, payment_hash)
+            if last is None:
+                time.sleep(0.5)
+                continue
+            if expected is None or last.get("status") == expected:
+                return last
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"{fiber.tmp_path} TLC {payment_hash} status {last} != {expected}"
+        )
+
+    def _submit_signed_commitment(self):
+        musig = self.peer.musig2(self.channel_id)
+        numbers = []
+        for key in ("local_commitment_number", "remote_commitment_number"):
+            raw = musig.get(key)
+            if raw is None:
+                continue
+            number = int(raw, 16) if isinstance(raw, str) else int(raw)
+            numbers.extend([number, max(number - 1, 0), number + 1])
+        errors = []
+        tried = set()
+        for number in numbers:
+            if number in tried:
+                continue
+            tried.add(number)
+            try:
+                return self.attacker.get_client().call(
+                    "submit_commitment_transaction",
+                    [
+                        {
+                            "channel_id": self.channel_id,
+                            "commitment_number": hex(number),
+                        }
+                    ],
+                )
+            except Exception as err:
+                errors.append(f"{number}: {err}")
+        raise AssertionError(
+            "attacker could not submit the signed remote commitment: "
+            f"musig={musig} errors={errors}"
+        )
+
+    def _commit_signed_commitment(self, timeout=60):
+        deadline = time.time() + timeout
+        last_error = None
+        while time.time() < deadline:
+            try:
+                submitted = self._submit_signed_commitment()
+                self.Miner.miner_until_tx_committed(self.node, submitted["tx_hash"])
+                return submitted
+            except Exception as error:
+                last_error = error
+                if "Expiry" not in str(error):
+                    raise
+                time.sleep(1)
+        raise TimeoutError(
+            f"signed commitment did not mature within {timeout}s: {last_error}"
+        )
+
+    def _wait_payment_success_with_mining(self, fiber, payment_hash, timeout=180):
+        deadline = time.time() + timeout
+        last = None
+        while time.time() < deadline:
+            last = fiber.get_client().get_payment({"payment_hash": payment_hash})
+            if last["status"] == "Success":
+                return last
+            if last["status"] == "Failed":
+                raise AssertionError(f"payment failed during on-chain settle: {last}")
+            # Watchtower checks asynchronously. Keep producing blocks until its
+            # preimage claim and the payer reconciliation are both committed.
+            self.Miner.miner_with_version(self.node, "0x0")
+            time.sleep(1)
+        raise TimeoutError(
+            f"payment {payment_hash} did not settle on-chain within {timeout}s: {last}"
+        )
+
+    def _wait_outbound_remote_removed(self, fiber, payment_hash, timeout=90):
+        last = None
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            last = self._tlc(fiber, payment_hash)
+            if last is None:
+                return None
+            if last.get("status") == {"Outbound": "RemoteRemoved"}:
+                return last
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"{fiber.tmp_path} offered TLC {payment_hash} did not "
+            f"reconcile to RemoteRemoved: {last}"
+        )
+
+    def test_localannounced_offered_tlc_reconciles_after_onchain_settle(self):
+        """On-chain P settle closes the LocalAnnounced origin payment."""
+        preimage = self.generate_random_preimage()
+        payment_hash = sha256_hex(preimage)
+        invoice = self.attacker.get_client().new_invoice(
+            {
+                "amount": hex(PAYMENT_AMOUNT),
+                "currency": "Fibd",
+                "description": "F-0361 LocalAnnounced on-chain reconcile",
+                "payment_hash": payment_hash,
+                "hash_algorithm": "sha256",
+                "final_expiry_delta": hex(FINAL_EXPIRY_DELTA),
+            }
+        )
+
+        # Attacker already has the signed remote commitment after AddTlc+CS.
+        # Withhold the ACK that would move the victim to Committed.
+        self.peer.intercept(
+            self.channel_id,
+            drop_out=["RevokeAndAck", "CommitmentSigned", "RemoveTlc"],
+            drop_raa=True,
+        )
+
+        payment = self.victim.get_client().send_payment(
+            {
+                "invoice": invoice["invoice_address"],
+                "max_fee_rate": hex(1000000000000000),
+            }
+        )
+        assert payment["payment_hash"] == payment_hash
+        self.wait_payment_state(self.victim, payment_hash, "Inflight", timeout=60)
+        victim_tlc = self._wait_tlc(
+            self.victim, payment_hash, {"Outbound": "LocalAnnounced"}
+        )
+        attacker_tlc = self._wait_tlc(self.attacker, payment_hash)
+        assert "Inbound" in attacker_tlc.get("status", {}), attacker_tlc
+        assert victim_tlc.get("payment_hash") == payment_hash
+
+        # Honest preimage is known to the attacker; stock create_preimage accepts it.
+        self.attacker.get_client().call(
+            "create_preimage",
+            [{"payment_hash": payment_hash, "preimage": preimage}],
+        )
+
+        self._commit_signed_commitment()
+        self.node.getClient().generate_epochs("0x1", wait_time=0)
+
+        # PR #1630: LocalAnnounced offered TLCs are in the remote commitment,
+        # so on-chain P must finish the origin payment.
+        payment_after = self._wait_payment_success_with_mining(
+            self.victim, payment_hash
+        )
+        assert payment_after.get("payment_preimage") == preimage, payment_after
+
+        victim_tlc = self._wait_outbound_remote_removed(self.victim, payment_hash)
+        if victim_tlc is not None:
+            assert victim_tlc["status"] == {"Outbound": "RemoteRemoved"}, victim_tlc

--- a/test_cases/fiber/devnet/security/test_f0361_router_watch_preimage_fallback.py
+++ b/test_cases/fiber/devnet/security/test_f0361_router_watch_preimage_fallback.py
@@ -1,0 +1,212 @@
+"""F-0361 regression: a live router relays LocalAnnounced on-chain fulfill.
+
+Alice (stock) -- Router (stock) -- Bob (debug attacker)
+
+Bob withholds the ACK so the router's outgoing TLC stays LocalAnnounced,
+then broadcasts that commitment and claims P on-chain. PR #1630 includes
+offered LocalAnnounced TLCs in on-chain fulfill collection, so the router
+relays RemoveTlc(Fulfill) upstream. Alice must reach Success and the
+router must not be left holding the incoming hop.
+"""
+
+import hashlib
+import time
+
+from framework.basic_p2p import P2pFiberTest
+from framework.p2p_peer import P2pPeer
+from framework.test_fiber import FiberConfigPath
+
+CKB = 100000000
+PAYMENT_AMOUNT = 1 * CKB
+CHANNEL_FUND = 200 * CKB
+FINAL_EXPIRY_DELTA = 24 * 60 * 60 * 1000
+
+
+def sha256_hex(preimage_hex):
+    raw = bytes.fromhex(preimage_hex.replace("0x", ""))
+    return "0x" + hashlib.sha256(raw).digest().hex()
+
+
+class TestF0361RouterWatchPreimageFallback(P2pFiberTest):
+    auto_open_channel = False
+    start_fiber_config = {"fiber_watchtower_check_interval_seconds": 5}
+
+    def _open_alice_router_bob(self):
+        self.alice = self.fiber1
+        # P2pFiberTest releases fiber2 before it starts the debug attacker.
+        # Start a live stock node explicitly for the middle hop instead of
+        # reusing that stopped Fiber object.
+        self.router = self.start_new_fiber(
+            self.generate_account(10000),
+            fiber_version=FiberConfigPath.CURRENT_DEV,
+        )
+        self.bob = self.attacker
+        self.peer = P2pPeer(self.bob)
+        self.bob.connect_peer(self.router)
+        time.sleep(1)
+        self.ch_alice = self.open_channel(
+            self.alice, self.router, CHANNEL_FUND, CHANNEL_FUND
+        )
+        self.ch_bob = self.open_channel(
+            self.router, self.bob, CHANNEL_FUND, CHANNEL_FUND
+        )
+        time.sleep(3)
+        self.wait_graph_channels_sync(self.alice, 2, timeout=90)
+        self.wait_graph_channels_sync(self.router, 2, timeout=90)
+        return self.ch_alice, self.ch_bob
+
+    def _channel(self, fiber, channel_id):
+        channels = fiber.get_client().list_channels({"include_closed": True})[
+            "channels"
+        ]
+        for channel in channels:
+            if channel["channel_id"] == channel_id:
+                return channel
+        raise AssertionError(f"channel {channel_id} not found on {fiber.tmp_path}")
+
+    def _tlc(self, fiber, channel_id, payment_hash):
+        channel = self._channel(fiber, channel_id)
+        for tlc in channel.get("pending_tlcs") or []:
+            if tlc.get("payment_hash") == payment_hash:
+                return tlc
+        return None
+
+    def _wait_tlc(self, fiber, channel_id, payment_hash, expected=None, timeout=60):
+        last = None
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            last = self._tlc(fiber, channel_id, payment_hash)
+            if last is None:
+                time.sleep(0.5)
+                continue
+            if expected is None or last.get("status") == expected:
+                return last
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"{fiber.tmp_path} {channel_id} TLC {payment_hash} "
+            f"status {last} != {expected}"
+        )
+
+    def _submit_signed_commitment(self, channel_id):
+        musig = self.peer.musig2(channel_id)
+        numbers = []
+        for key in ("local_commitment_number", "remote_commitment_number"):
+            raw = musig.get(key)
+            if raw is None:
+                continue
+            number = int(raw, 16) if isinstance(raw, str) else int(raw)
+            numbers.extend([number, max(number - 1, 0), number + 1])
+        errors = []
+        tried = set()
+        for number in numbers:
+            if number in tried:
+                continue
+            tried.add(number)
+            try:
+                return self.bob.get_client().call(
+                    "submit_commitment_transaction",
+                    [
+                        {
+                            "channel_id": channel_id,
+                            "commitment_number": hex(number),
+                        }
+                    ],
+                )
+            except Exception as err:
+                errors.append(f"{number}: {err}")
+        raise AssertionError(
+            "bob could not submit the signed remote commitment: "
+            f"musig={musig} errors={errors}"
+        )
+
+    def _mine_watchtower_rounds(self, rounds=4):
+        interval = self.start_fiber_config["fiber_watchtower_check_interval_seconds"]
+        deadline = time.time() + interval * rounds + 2
+        while time.time() < deadline:
+            pool = self.node.getClient().get_raw_tx_pool()
+            pending = list(pool.get("pending") or [])
+            if pending:
+                self.Miner.miner_until_tx_committed(self.node, pending[0])
+            else:
+                self.Miner.miner_with_version(self.node, "0x0")
+            time.sleep(1)
+
+    def test_live_router_recovers_upstream_after_localannounced_claim(self):
+        """Bob claims the LocalAnnounced hop; on-chain reconcile fulfills Alice."""
+        ch_alice, ch_bob = self._open_alice_router_bob()
+        preimage = self.generate_random_preimage()
+        payment_hash = sha256_hex(preimage)
+        invoice = self.bob.get_client().new_invoice(
+            {
+                "amount": hex(PAYMENT_AMOUNT),
+                "currency": "Fibd",
+                "description": "F-0361 live router LocalAnnounced on-chain fulfill",
+                "payment_hash": payment_hash,
+                "hash_algorithm": "sha256",
+                "final_expiry_delta": hex(FINAL_EXPIRY_DELTA),
+            }
+        )
+
+        self.peer.intercept(
+            ch_bob,
+            drop_out=["RevokeAndAck", "CommitmentSigned", "RemoveTlc"],
+            drop_raa=True,
+        )
+
+        payment = self.alice.get_client().send_payment(
+            {
+                "invoice": invoice["invoice_address"],
+                "max_fee_rate": hex(1000000000000000),
+            }
+        )
+        assert payment["payment_hash"] == payment_hash
+        self.wait_payment_state(self.alice, payment_hash, "Inflight", timeout=60)
+        self._wait_tlc(
+            self.router, ch_bob, payment_hash, {"Outbound": "LocalAnnounced"}
+        )
+        router_in = self._wait_tlc(self.router, ch_alice, payment_hash)
+        assert "Inbound" in router_in.get("status", {}), router_in
+
+        self.bob.get_client().call(
+            "create_preimage",
+            [{"payment_hash": payment_hash, "preimage": preimage}],
+        )
+        submitted = self._submit_signed_commitment(ch_bob)
+        self.Miner.miner_until_tx_committed(self.node, submitted["tx_hash"])
+        self.node.getClient().generate_epochs("0x1", wait_time=0)
+        self._mine_watchtower_rounds(4)
+        self.wait_invoice_state(self.bob, payment_hash, "Paid", timeout=90)
+
+        # PR #1630: LocalAnnounced offered TLC is collected as fulfilled and
+        # relayed upstream, so Alice is paid from the on-chain preimage.
+        self.wait_payment_state(self.alice, payment_hash, "Success", timeout=120)
+        payment_after = self.alice.get_client().get_payment(
+            {"payment_hash": payment_hash}
+        )
+        assert payment_after.get("payment_preimage") == preimage, payment_after
+
+        # The force-closed channel may retain its last LocalAnnounced TLC
+        # snapshot while waiting for commitment confirmation. The observable
+        # reconciliation contract is that the channel is closing on-chain and
+        # the preimage has already been relayed to the upstream hop.
+        router_out_channel = self._channel(self.router, ch_bob)
+        assert router_out_channel["state"]["state_name"] in (
+            "ShuttingDown",
+            "Closed",
+        ), router_out_channel
+        router_out = self._tlc(self.router, ch_bob, payment_hash)
+        if router_out is not None:
+            assert router_out["status"] in (
+                {"Outbound": "LocalAnnounced"},
+                {"Outbound": "RemoteRemoved"},
+            ), router_out
+
+        router_in_after = self._tlc(self.router, ch_alice, payment_hash)
+        if router_in_after is not None:
+            status = router_in_after.get("status") or {}
+            inbound = status.get("Inbound")
+            assert inbound in (
+                "LocalRemoved",
+                "RemoveWaitAck",
+                "RemoveAckConfirmed",
+            ), router_in_after

--- a/test_cases/fiber/devnet/security/test_musig2_nonce_reuse.py
+++ b/test_cases/fiber/devnet/security/test_musig2_nonce_reuse.py
@@ -1,0 +1,76 @@
+"""PR 1628: empty CS after dropped RAA must not emit reciprocal CommitmentSigned.
+
+Before the revert of `needs_nonce_rollover`, a stock victim would ACK an empty
+CommitmentSigned and then send another empty CS (signature A). That CS reused
+the funding pubnonce together with ClosingSigned (B) and the on-chain
+aggregate (C), which recovered the victim funding key.
+
+After PR 1628 the victim still ACKs, but must not send that extra CS.
+
+    ./venv/bin/pytest test_cases/fiber/devnet/security/test_musig2_nonce_reuse.py -k test_no_raa_reuses_funding_nonce_and_recovers_key --tb=short
+"""
+
+from __future__ import annotations
+
+import time
+
+from framework.attack_fnn import requires_attack_fnn
+from framework.basic_fiber import FiberTest
+from framework.test_fiber import FiberConfigPath
+
+
+@requires_attack_fnn
+class TestMusig2NonceReuse(FiberTest):
+    """Stock victim + attacker fnn. Only the attacker exposes attack Dev RPCs."""
+
+    fiber_version = FiberConfigPath.CURRENT_DEV
+
+    def test_no_raa_reuses_funding_nonce_and_recovers_key(self):
+        victim = self.fiber1
+        attacker = self.start_new_fiber(
+            self.generate_account(10000),
+            fiber_version=FiberConfigPath.ATTACK_DEV,
+        )
+        # Skip the helper's rebalance payment so the channel stays TLC-empty.
+        channel_id = self.open_channel(victim, attacker, 200 * 100000000, 0)
+
+        attacker_client = attacker.get_client()
+        attacker_client.set_fiber_message_intercept(
+            {
+                "channel_id": channel_id,
+                "suppress_outbound_revoke_and_ack": True,
+                "capture_inbound": True,
+            }
+        )
+
+        attacker_client.send_raw_channel_message(
+            {
+                "channel_id": channel_id,
+                "kind": "commitment_signed",
+            }
+        )
+
+        inbox = []
+        raa = self._wait_captured(attacker_client, inbox, "RevokeAndAck", 10)
+        assert raa is not None, "victim must ACK the empty CommitmentSigned"
+
+        extra_cs = self._wait_captured(attacker_client, inbox, "CommitmentSigned", 5)
+        assert extra_cs is None, (
+            "victim sent a reciprocal empty CommitmentSigned (signature A); "
+            "that CS reused the funding nonce and recovered the funding key"
+        )
+
+        channels = victim.get_client().list_channels({})["channels"]
+        match = next(c for c in channels if c["channel_id"] == channel_id)
+        assert match["state"]["state_name"] == "ChannelReady"
+
+    def _wait_captured(self, client, inbox, kind, timeout):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            result = client.take_captured_fiber_messages() or {}
+            inbox.extend(result.get("messages") or [])
+            for index, message in enumerate(inbox):
+                if message.get("kind") == kind:
+                    return inbox.pop(index)
+            time.sleep(0.2)
+        return None


### PR DESCRIPTION
## Summary

- add a reusable `requires_attack_fnn` marker plus the P2P interception harness
- cover the PR 1628 MuSig2 nonce-rollover regression
- cover three F-0361 `LocalAnnounced` on-chain reconciliation paths: direct payer, live router, and CCH `receive_btc` through LND
- add a dedicated GitHub Actions job that discovers all tests marked `requires_attack_fnn`, including Bitcoin Core and LND setup for the CCH case

`test_f0061_prefix_preimage_unknown.py` remains outside this PR because its attack peer additionally needs a forced `create_preimage` capability that the pinned `p2p-tap` FNN does not expose.

## FNN provenance

The workflow builds both binaries from source with the debug profile (the `p2p-tap` RPC registration is debug-only), instead of consuming an unnamed local artifact:

- stock/honest FNN: `nervosnetwork/fiber:develop`
- instrumented/attack FNN: `gpBlockchain/fiber:p2p-tap`

The build script resolves both branches on every run, verifies that the resolved attack commit descends from the resolved stock commit, places the binaries at `download/fiber/current/fnn` and `download/fiber/attack/fnn`, checks the debug RPC strings, and records the branch refs, resolved commits, build profile, and SHA-256 hashes in the CI artifact. Manual dispatch inputs can override both repositories and branches.

## Marked regressions

- `test_musig2_nonce_reuse.py`
- `test_f0361_localannounced_onchain_reconcile.py`
- `test_f0361_router_watch_preimage_fallback.py`
- `test_f0361_cch_receive_btc_inflight.py`

## Verification

- Black check on all changed Python files
- Python compilation of the added tests and downloader change
- workflow YAML parsing and `bash -n scripts/build_attack_fnn.sh`
- `pytest --collect-only --strict-markers -m requires_attack_fnn test_cases/fiber/devnet/security`: 4 selected, 5 deselected
- local `test_musig2_nonce_reuse.py`: passed
- local `test_f0361_router_watch_preimage_fallback.py`: passed
- local `test_f0361_localannounced_onchain_reconcile.py`: passed with stock and instrumented FNN processes
- GitHub Actions `attack-fnn-regressions`: pending for commit `0d3d683b`
